### PR TITLE
xmsannotator - pin the version of docker image we are using

### DIFF
--- a/tools/xmsannotator/xmsannotator_macros.xml
+++ b/tools/xmsannotator/xmsannotator_macros.xml
@@ -2,7 +2,7 @@
     <token name="@TOOL_VERSION@">1.3.2</token>
     <xml name="requirements">
         <requirements>
-            <container type="docker">recetox/xmsannotator:latest</container>
+            <container type="docker">recetox/xmsannotator:1.3.2-recetox0</container>
         </requirements>
     </xml>
 


### PR DESCRIPTION
I made a corresponding tag in the xmsannotator repo: https://github.com/RECETOX/xMSannotator/releases/tag/1.3.2-recetox0