### PR TITLE
Use latest docker image for Retip

### DIFF
--- a/tools/retip/macros.xml
+++ b/tools/retip/macros.xml
@@ -2,7 +2,7 @@
     <token name="@TOOL_VERSION@">0.5.4</token>
     <xml name="requirements">
         <requirements>
-            <container type="docker">recetox/retip:@TOOL_VERSION@-recetox2</container>
+            <container type="docker">recetox/retip:@TOOL_VERSION@-recetox3</container>
         </requirements>
     </xml>
     <xml name="citations">


### PR DESCRIPTION
Docker image has been updated with the changes made in the [PR](https://github.com/RECETOX/Retip/pull/8).