### PR TITLE
revert exporter tool refactoring

### DIFF
--- a/tools/export_to_path/export_to_path.py
+++ b/tools/export_to_path/export_to_path.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 import optparse
 import os
+import os.path
 import re
 import shutil
 import sys
@@ -14,50 +15,38 @@ Inspired by @nsoranzo's https://github.com/TGAC/earlham-galaxytools/tree/master/
 parser = optparse.OptionParser()
 parser.add_option('-d', '--export_dir', help='Directory where to export the datasets')
 (options, args) = parser.parse_args()
+if not options.export_dir:
+    parser.error('Export directory cannot be empty')
 
+dir_prefix = "/mnt/sally"
+dir_suffix = 'mzML_profile'
+full_export_dir = os.path.join(dir_prefix, options.export_dir.lstrip(os.sep), dir_suffix)
+real_export_dir = os.path.realpath(full_export_dir)
+if not real_export_dir.startswith(dir_prefix):
+    raise Exception("'%s' must be a subdirectory of '%s'" % (real_export_dir, dir_prefix))
+if not os.path.exists(real_export_dir):
+    os.makedirs(real_export_dir)
 
-def get_path():
-    dir_prefix = '/mnt/sally'
-    dir_suffix = 'mzML_profile'
-    if not options.export_dir:
-        parser.error('Input cannot be empty')
-    elif not os.path.isdir(os.path.join(dir_prefix, options.export_dir.lstrip(os.sep))):
-        parser.error('Subdirectory must exist')
-    else:
-        return os.path.join(dir_prefix, options.export_dir.lstrip(os.sep), dir_suffix)
-
-
-export_path = get_path()
-
-
-if not os.path.exists(export_path):
-    os.makedirs(export_path)
-
-    
-def get_arguments():
-    dataset_paths = args[::3]
-    dataset_names = args[1::3]
-    dataset_extensions = args[2::3]
-    return zip(dataset_paths, dataset_names, dataset_extensions)
-
+dataset_paths = args[::3]
+dataset_names = args[1::3]
+dataset_exts = args[2::3]
 exit_code = 0
-
-for dp, dn, de in get_arguments():
-    '''
-    Copied from django https://github.com/django/django/blob/master/django/utils/text.py
-    '''
+for dp, dn, de in zip(dataset_paths, dataset_names, dataset_exts):
+    """
+    Copied from get_valid_filename from django
+    https://github.com/django/django/blob/master/django/utils/text.py
+    """
     dn_de = "%s.%s" % (dn, de)
     dn_de_safe = re.sub(r'(?u)[^-\w.]', '', dn_de.strip().replace(' ', '_'))
-
-    if os.path.isfile(os.path.join(export_path, dn_de_safe)):
-        raise Exception("Error copying dataset '%s' to '%s'. Cannot overwrite existing dataset" % (dn, export_path))
+    dest = os.path.join(real_export_dir, dn_de_safe)
+    if os.path.isfile(dest):
+        raise Exception("Error copying dataset '%s' to '%s'. Cannot overwrite existing dataset" % (dn, dest))
     else:
         try:
-            shutil.copy2(dp, export_path)
-            print("Dataset '%s' copied to '%s'" % (dn, export_path))
+            shutil.copy2(dp, dest)
+            print("Dataset '%s' copied to '%s'" % (dn, dest))
         except Exception as e:
-            msg = "Error copying dataset '%s' to '%s', %s" % (dn, export_path, e)
+            msg = "Error copying dataset '%s' to '%s', %s" % (dn, dest, e)
             print(msg, file=sys.stderr)
             exit_code = 1
-
 sys.exit(exit_code)


### PR DESCRIPTION
This PR reverts https://github.com/RECETOX/galaxytools/pull/32 and https://github.com/RECETOX/galaxytools/commit/271f30bf9316550dbc6b4728c8b06d7d5f3bb3eb

main reasons:
* the refactoring seems to not have been properly tested
* contains unreachable code

Additionally the subsequent PR (https://github.com/RECETOX/galaxytools/pull/38) adds undefined variables.


@maximskorik Refactoring is a fine endeavor, but should go hand in hand with proper testing of code. This particular tool is suitable to be tested locally (e.g. by changing `dir_prefix = "/mnt/sally"` to some local path for testing and serving the tool with `planemo serve`).  I've tested this a bit at https://github.com/RECETOX/galaxytools/commit/c83009184c64c4178e132f9e12170818c52f7db7 and that seems to me to be the last functioning version - that is the version I am reverting to here.

When sorting through the commits for the refactoring PR you can take advantage of `git cherry-pick`, that applies one commit (based on commit hash) to your current git repo.

If you'd like to work on this please open a new PR with the refactoring following the recommendations I outlined here: https://github.com/RECETOX/galaxytools/pull/32#issuecomment-721357294