### PR TITLE
lint matchms

### DIFF
--- a/tools/matchms/matchms_wrapper.py
+++ b/tools/matchms/matchms_wrapper.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 import pandas
-
 from matchms import calculate_scores
 from matchms.importing import load_from_msp
 from matchms.similarity import (


### PR DESCRIPTION
fix extra space in imports