### PR TITLE
Fixed RAMClustR CSV by setting idmsms to NULL if not set

### DIFF
--- a/tools/ramclustr/ramclustr_csv.xml
+++ b/tools/ramclustr/ramclustr_csv.xml
@@ -18,7 +18,11 @@
             -e 'source("${__tool_directory__}/ramclustr_wrapper.R")'
             -e 'x <- ramclustr_csv(
                 ms="$ms_csv.ms",
-                idmsms="$ms_csv.idmsms",
+                #if $ms_csv.idmsms
+                    idmsms="$ms_csv.idmsms",
+                #else
+                    idmsms=NULL,
+                #end if
                 feature_delimiter="$ms_csv.feature_delimiter",
                 sample_name_column = $ms_csv.sample_name_column,
                 retention_time_column= $ms_csv.retention_time_column,

--- a/tools/ramclustr/ramclustr_csv.xml
+++ b/tools/ramclustr/ramclustr_csv.xml
@@ -10,7 +10,7 @@
     <inputs>
         <expand macro="parameters_csv" />
         <expand macro="parameters_required" />
-        <expand macro="parameters_optional" />
+        <expand macro="parameters_optional_csv" />
     </inputs>
 
     <command detect_errors="aggressive"><![CDATA[
@@ -18,11 +18,7 @@
             -e 'source("${__tool_directory__}/ramclustr_wrapper.R")'
             -e 'x <- ramclustr_csv(
                 ms="$ms_csv.ms",
-                #if $ms_csv.idmsms
-                    idmsms="$ms_csv.idmsms",
-                #else
-                    idmsms=NULL,
-                #end if
+                idmsms="$ms_csv.idmsms",
                 feature_delimiter="$ms_csv.feature_delimiter",
                 sample_name_column = $ms_csv.sample_name_column,
                 retention_time_column= $ms_csv.retention_time_column,
@@ -41,9 +37,7 @@
                 cor_method = "$required.cor_method",
                 rt_only_low_n = $required.rt_only_low_n,
                 replace_zeros = $required.replace_zeros,
-                #if $optional.st
-                    st = $optional.st,
-                #end if
+                st = $ms_csv.st,
                 #if $optional.maxt
                     maxt = $optional.maxt,
                 #end if

--- a/tools/ramclustr/ramclustr_macros.xml
+++ b/tools/ramclustr/ramclustr_macros.xml
@@ -8,6 +8,8 @@
             <param label="sample_name_column" name="sample_name_column" type="integer" value="1" help="which column from the csv file contains sample names?" />
             <param label="feature_delimiter" name="feature_delimiter" type="text" value="_" help="Only required if ms input is set! How feature mz and rt are delimited in csv import column header e.g. ='-'" />
             <param label="retention_time_column" name="retention_time_column" type="integer" value="2" help="which position in delimited column header represents the retention time (csv only)" />
+            <param label="st" name="st" type="float" value="1" help="sigma t - time similarity decay value. A recommended starting point is half the value of 
+      your average chromatographic peak width at half max (seconds))." />
         </section>
     </xml>
 
@@ -64,9 +66,17 @@
         </section>
     </xml>
 
-    <xml name="parameters_optional">
+    <xml name="parameters_optional_xcms">
         <section name="optional" title="Optional Parameters" expanded="false">
-            <param label="st" name="st" type="float" optional="true" help="sigma t - time similarity decay value " />
+            <param label="st" name="st" type="float" optional="true" help="sigma t - time similarity decay value. A recommended starting point is half the value of 
+      your average chromatographic peak width at half max (seconds))." />
+            <param label="fftempdir" name="fftempdir" type="text" optional="true" help="valid path: if there are file size limitations on the default ff pacakge temp directory  - getOptions('fftempdir') - you can change the directory used as the fftempdir with this option." />
+            <param label="maxt" name="maxt" type="integer" optional="true" help="maximum time difference to calculate retention similarity for - all values beyond this are assigned similarity of zero" />
+        </section>
+    </xml>
+
+        <xml name="parameters_optional_csv">
+        <section name="optional" title="Optional Parameters" expanded="false">
             <param label="fftempdir" name="fftempdir" type="text" optional="true" help="valid path: if there are file size limitations on the default ff pacakge temp directory  - getOptions('fftempdir') - you can change the directory used as the fftempdir with this option." />
             <param label="maxt" name="maxt" type="integer" optional="true" help="maximum time difference to calculate retention similarity for - all values beyond this are assigned similarity of zero" />
         </section>

--- a/tools/ramclustr/ramclustr_wrapper.R
+++ b/tools/ramclustr/ramclustr_wrapper.R
@@ -83,6 +83,9 @@ ramclustr_csv <- function(
     maxt = NULL,
     fftempdir = NULL
 ) {
+    if(!file.exists(idmsms))
+        idmsms = NULL
+        
     x <- RAMClustR::ramclustR(
         ms = ms,
         idmsms = idmsms,

--- a/tools/ramclustr/ramclustr_wrapper.R
+++ b/tools/ramclustr/ramclustr_wrapper.R
@@ -83,9 +83,9 @@ ramclustr_csv <- function(
     maxt = NULL,
     fftempdir = NULL
 ) {
-    if(!file.exists(idmsms))
-        idmsms = NULL
-        
+    if (!file.exists(idmsms))
+        idmsms <- NULL
+    
     x <- RAMClustR::ramclustR(
         ms = ms,
         idmsms = idmsms,

--- a/tools/ramclustr/ramclustr_wrapper.R
+++ b/tools/ramclustr/ramclustr_wrapper.R
@@ -85,7 +85,7 @@ ramclustr_csv <- function(
 ) {
     if (!file.exists(idmsms))
         idmsms <- NULL
-    
+
     x <- RAMClustR::ramclustR(
         ms = ms,
         idmsms = idmsms,

--- a/tools/ramclustr/ramclustr_xcms.xml
+++ b/tools/ramclustr/ramclustr_xcms.xml
@@ -10,7 +10,7 @@
     <inputs>
         <param name="input_xcms" label="input_xcms" type="data" format="rdata.xcms.fillpeaks" help=": containing grouped feature data for clustering by ramclustR" />
         <expand macro="parameters_required" />
-        <expand macro="parameters_optional" />
+        <expand macro="parameters_optional_xcms" />
     </inputs>
 
     <command detect_errors="aggressive"><![CDATA[


### PR DESCRIPTION
Fixed RAMClustR CSV by setting idmsms to NULL if not set, because the script tries to load the file even if it is 'None'.

fixes #76 