### PR TITLE
rewrite export tool to work with new thermo converter

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -1,1 +1,2 @@
 tools/biotransformer
+tools/export_to_path

--- a/tools/export_to_path/export_to_path.py
+++ b/tools/export_to_path/export_to_path.py
@@ -25,20 +25,25 @@ if not os.path.exists(export_dir):
 #  Make sure program will never write outside of the mounted target directory.
 if not os.path.commonpath([os.path.realpath(options.remote_path), SALLY_MOUNT_PREFIX]) == SALLY_MOUNT_PREFIX:
     raise Exception(f"Invalid export path supplied: {options.remote_path}")
-remote_paths = [options.remote_path]
-if len(args) > 1:
-    remote_paths.append(f"{options.remote_path[:-5]}.json")
-if len(args) == 3:
-    remote_paths.append(f"{options.remote_path[:-5]}.txt")
-for dataset_path, remote_path in zip(args, remote_paths):
-    if os.path.isfile(remote_path):
-        raise Exception(f"Error copying dataset to {remote_path}. File already exists.")
+dataset_paths = args[::2]
+dataset_exts = args[1::2]
+for dataset_path, dataset_ext in zip(dataset_paths, dataset_exts):
+    if dataset_ext == "mzml":
+        destination = options.remote_path
+    elif dataset_ext == "json":
+        destination = f"{options.remote_path[:-5]}.json"
+    elif dataset_ext == "txt":
+        destination = f"{options.remote_path[:-5]}.txt"
+    else:
+        raise Exception(f"Uknown extension received: {dataset_ext}.")
+    if os.path.isfile(destination):
+        raise Exception(f"Error copying dataset to {destination}. File already exists.")
     else:
         try:
-            shutil.copyfile(dataset_path, remote_path)
-            print(f"Dataset {dataset_path} copied to {remote_path}")
+            shutil.copyfile(dataset_path, destination)
+            print(f"Dataset {dataset_path} copied to {destination}")
         except Exception as e:
-            msg = f"Dataset {dataset_path} couldn't be copied to {remote_path}. Exception {e}"
+            msg = f"Dataset {dataset_path} couldn't be copied to {destination}. Exception {e}"
             print(msg, file=sys.stderr)
             exit_code = 1
 sys.exit(exit_code)

--- a/tools/export_to_path/export_to_path.py
+++ b/tools/export_to_path/export_to_path.py
@@ -25,6 +25,8 @@ if not os.path.exists(export_dir):
 #  Make sure program will never write outside of the mounted target directory.
 if not os.path.commonpath([os.path.realpath(options.remote_path), SALLY_MOUNT_PREFIX]) == SALLY_MOUNT_PREFIX:
     raise Exception(f"Invalid export path supplied: {options.remote_path}")
+if len(args) < 2:
+    raise Exception(f"At least one dataset to export is required. Supplied: {args}")
 dataset_paths = args[::2]
 dataset_exts = args[1::2]
 for dataset_path, dataset_ext in zip(dataset_paths, dataset_exts):

--- a/tools/export_to_path/export_to_path.py
+++ b/tools/export_to_path/export_to_path.py
@@ -1,53 +1,44 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+
 import optparse
 import os
 import os.path
-import re
 import shutil
 import sys
 
 '''
 Inspired by @nsoranzo's https://github.com/TGAC/earlham-galaxytools/tree/master/tools/export_to_cluster/
 '''
-
+SALLY_MOUNT_PREFIX = "/mnt/sally/000020-Shares/rcx-da"
 exit_code = 0
-dir_prefix = "/mnt/sally"
-dir_suffix = 'mzML_profile'
 parser = optparse.OptionParser()
-parser.add_option('-d', '--export_dir', help='Directory where to export the datasets')
+parser.add_option('-p', '--remote_path', help='Remote path to mzML')
+#  remote_path = "/mnt/sally/000020-Shares/rcx-da/H2020_HBM4EU/2020/WP16_Specimen/HBM4EU_ESI_positive_WP_urine_MS1/HBM4EU_Fieldwork_1_Batch_1-20201001-CMV/mzML_profile/Tribrid_201001_051-350697_POS_MU.mzML"
 (options, args) = parser.parse_args()
-if not options.export_dir:
-    parser.error('Export directory cannot be empty')
-if not args or (len(args) % 3) != 0:
-    raise Exception("Incorrect number of arguments specified.")
-full_export_dir = os.path.join(dir_prefix, options.export_dir.lstrip(os.sep), dir_suffix)
-real_export_dir = os.path.realpath(full_export_dir)
-if not real_export_dir.startswith(dir_prefix):
-    raise Exception("'%s' must be a subdirectory of '%s'" % (real_export_dir, dir_prefix))
-if not os.path.exists(real_export_dir):
-    os.makedirs(real_export_dir)
-dataset_paths = args[::3]
-dataset_names = args[1::3]
-dataset_exts = args[2::3]
-
-for dp, dn, de in zip(dataset_paths, dataset_names, dataset_exts):
-    """
-    Copied from get_valid_filename from django
-    https://github.com/django/django/blob/master/django/utils/text.py
-    """
-    dn_de = "%s.%s" % (dn, de)
-    dn_de_safe = re.sub(r'(?u)[^-\w.]', '', dn_de.strip().replace(' ', '_'))
-    dest = os.path.join(real_export_dir, dn_de_safe)
-    if os.path.isfile(dest):
-        raise Exception("Error copying dataset '%s' to '%s'. Cannot overwrite existing dataset" % (dn, dest))
+if not options.remote_path:
+    parser.error('Remote path cannot be empty.')
+export_dir, export_file = os.path.split(options.remote_path)
+if not os.path.exists(export_dir):
+    os.makedirs(export_dir)
+#  Make sure program will never write outside of the mounted target directory.
+if not os.path.commonpath([os.path.realpath(options.remote_path), SALLY_MOUNT_PREFIX]) == SALLY_MOUNT_PREFIX:
+    raise Exception(f"Invalid export path supplied: {options.remote_path}")
+remote_paths = [options.remote_path]
+if len(args) > 1:
+    remote_paths.append(f"{options.remote_path[:-5]}.json")
+if len(args) == 3:
+    remote_paths.append(f"{options.remote_path[:-5]}.txt")
+for dataset_path, remote_path in zip(args, remote_paths):
+    if os.path.isfile(remote_path):
+        raise Exception(f"Error copying dataset to {remote_path}. File already exists.")
     else:
         try:
-            shutil.copyfile(dp, dest)
-            print("Dataset '%s' copied to '%s'" % (dn, dest))
+            shutil.copyfile(dataset_path, remote_path)
+            print(f"Dataset {dataset_path} copied to {remote_path}")
         except Exception as e:
-            msg = "Error copying dataset '%s' to '%s', %s" % (dn, dest, e)
+            msg = f"Dataset {dataset_path} couldn't be copied to {remote_path}. Exception {e}"
             print(msg, file=sys.stderr)
             exit_code = 1
 sys.exit(exit_code)

--- a/tools/export_to_path/export_to_path.xml
+++ b/tools/export_to_path/export_to_path.xml
@@ -1,19 +1,28 @@
-<tool id="export_to_path" name="export to path" version="0.0.1">
-    <description> on Sally</description>
+<tool id="export_to_path" name="export to path" version="0.0.2">
+    <description>on a filesystem accessible to compute node</description>
     <requirements>
         <requirement type="package" version="3.6">python</requirement>
     </requirements>
     <command detect_errors="aggressive"><![CDATA[
-python '$__tool_directory__/export_to_path.py' -d '$export_dir'
-#for $d,$m in zip($datasets, $metadata)
-    '${d}' '${d.element_identifier}' '${d.ext}' '${m}' '${m.element_identifier}' '${m.ext}'
-#end for
+python '$__tool_directory__/export_to_path.py'
+-p '$remote_path'
+'${mzml_dataset}'
+
+#if $json_metadata
+  '${json_metadata}'
+#end if
+
+#if $txt_metadata
+  '${txt_metadata}'
+#end if
+
 > '$log'
     ]]></command>
     <inputs>
-        <param name="datasets" type="data" format="data" multiple="true" label="Datasets to export" />
-        <param name="metadata" type="data" format="data" multiple="true" label="Metadata to export" optional="true"/>
-        <param name="export_dir" type="text" value="" label="Directory where RAW_profile and mzML_profile reside" help="relative path to Sally's home e.g. share/path/to/project">
+        <param name="mzml_dataset" type="data" format="mzml" label="mzML Dataset to export" />
+        <param name="json_metadata" type="data" format="json" label="JSON metadata to export" optional="true"/>
+        <param name="txt_metadata" type="data" format="txt" label="TXT metadata to export" optional="true"/>
+        <param name="remote_path" type="text" value="" label="Remote path of the new mzML dataset." help="Full absolute path to the new mzml dataset to export.">
             <validator type="empty_field" />
             <sanitizer sanitize="false" />
         </param>

--- a/tools/export_to_path/export_to_path.xml
+++ b/tools/export_to_path/export_to_path.xml
@@ -6,14 +6,14 @@
     <command detect_errors="aggressive"><![CDATA[
 python '$__tool_directory__/export_to_path.py'
 -p '$remote_path'
-'${mzml_dataset}'
+'${mzml_dataset}' '${mzml_dataset.ext}'
 
 #if $json_metadata
-  '${json_metadata}'
+  '${json_metadata}' '${json_metadata.ext}'
 #end if
 
 #if $txt_metadata
-  '${txt_metadata}'
+  '${txt_metadata}' '${txt_metadata.ext}'
 #end if
 
 > '$log'

--- a/tools/export_to_path/export_to_path.xml
+++ b/tools/export_to_path/export_to_path.xml
@@ -6,7 +6,10 @@
     <command detect_errors="aggressive"><![CDATA[
 python '$__tool_directory__/export_to_path.py'
 -p '$remote_path'
+
+#if $mzml_dataset
 '${mzml_dataset}' '${mzml_dataset.ext}'
+#end if
 
 #if $json_metadata
   '${json_metadata}' '${json_metadata.ext}'
@@ -19,7 +22,7 @@ python '$__tool_directory__/export_to_path.py'
 > '$log'
     ]]></command>
     <inputs>
-        <param name="mzml_dataset" type="data" format="mzml" label="mzML Dataset to export" />
+        <param name="mzml_dataset" type="data" format="mzml" label="mzML Dataset to export" optional="true"/>
         <param name="json_metadata" type="data" format="json" label="JSON metadata to export" optional="true"/>
         <param name="txt_metadata" type="data" format="txt" label="TXT metadata to export" optional="true"/>
         <param name="remote_path" type="text" value="" label="Remote path of the new mzML dataset." help="Full absolute path to the new mzml dataset to export.">


### PR DESCRIPTION
also abandon efforts to make it generic, added complexity is not worth it imo


The Thermo converter v1.3.2 does not detect outputs using the collection file discovery engine hence we do not have the information about the original filenames anymore. I took the opportunity to simplify the code and just allow the caller to specify the full path of the mzML to be created, the metadata file names are inferred from the same name.