### PR TITLE
xMSannotator - remove explicit conversion causing weird bug

### DIFF
--- a/tools/xmsannotator/xmsannotator_advanced.xml
+++ b/tools/xmsannotator/xmsannotator_advanced.xml
@@ -1,4 +1,4 @@
-<tool id="xmsannotator_advanced" name="xMSannotator (advanced)" version="@TOOL_VERSION@+galaxy2">
+<tool id="xmsannotator_advanced" name="xMSannotator (advanced)" version="@TOOL_VERSION@+galaxy3">
     <macros>
         <import>xmsannotator_macros.xml</import>
     </macros>

--- a/tools/xmsannotator/xmsannotator_advanced.xml
+++ b/tools/xmsannotator/xmsannotator_advanced.xml
@@ -30,7 +30,7 @@
                 deep_split = as.integer($clustering.deep_split),
                 network_type = "$clustering.network_type",
             #if $scoring.expected_adducts
-                expected_adducts = load_expected_adducts_csv("${$scoring.expected_adducts}"),
+                expected_adducts = load_expected_adducts_csv("${scoring.expected_adducts}"),
             #end if
             #if $scoring.boost_compounds
                 boost_compounds = load_boost_compounds_csv("${scoring.boost_compounds}"),

--- a/tools/xmsannotator/xmsannotator_advanced.xml
+++ b/tools/xmsannotator/xmsannotator_advanced.xml
@@ -30,10 +30,10 @@
                 deep_split = as.integer($clustering.deep_split),
                 network_type = "$clustering.network_type",
             #if $scoring.expected_adducts
-                expected_adducts = load_expected_adducts_csv("${$scoring.expected_adducts_csv}"),
+                expected_adducts = load_expected_adducts_csv("${$scoring.expected_adducts}"),
             #end if
             #if $scoring.boost_compounds
-                boost_compounds = load_boost_compounds_csv("${scoring.boost_compounds_csv}"),
+                boost_compounds = load_boost_compounds_csv("${scoring.boost_compounds}"),
             #end if
                 redundancy_filtering = $scoring.redundancy_filtering,
                 n_workers = \${GALAXY_SLOTS:-1}
@@ -91,22 +91,20 @@
                     cluster. Otherwise, do not account for cluster membership.
                 </help>
             </param>
-            <param name="expected_adducts" type="data" format="csv,tsv" optional="true">
+            <param name="expected_adducts" type="data" format="csv" optional="true">
                 <label>Expected adducts</label>
                 <help>
                     Require the presence of certain adducts for a high confidence match. By default, at least the
                     presence of an M+H adduct is required for a high confidence match.
                 </help>
-                <conversion name="expected_adducts_csv" type="csv"/>
             </param>
-            <param name="boost_compounds" type="data" format="csv,tsv" optional="true">
+            <param name="boost_compounds" type="data" format="csv" optional="true">
                 <label>Validated compounds score boosting (optional)</label>
                 <help>
                     Table of previously validated compounds to boost their scores and confidence levels.
                     The 1st column of the table must contain IDs of compounds.
                     The optional 2nd and 3rd columns may contain mz values and retention times.
                 </help>
-                <conversion name="boost_compounds_csv" type="csv"/>
             </param>
             <param name="min_isp" type="integer" min="0" value="1">
                 <label>Minimum number of expected isotopes</label>


### PR DESCRIPTION
Galaxy Traceback:
```
Traceback (most recent call last):
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/__init__.py", line 1657, in handle_single_execution
    flush_job=flush_job,
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/__init__.py", line 1745, in execute
    return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/actions/__init__.py", line 311, in execute
    history, inp_data, inp_dataset_collections, preserved_tags, all_permissions = self._collect_inputs(tool, trans, incoming, history, current_user_roles, collection_info)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/actions/__init__.py", line 263, in _collect_inputs
    inp_data, all_permissions = self._collect_input_datasets(tool, incoming, trans, history=history, current_user_roles=current_user_roles, collection_info=collection_info)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/actions/__init__.py", line 209, in _collect_input_datasets
    tool.visit_inputs(param_values, visitor)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/__init__.py", line 1532, in visit_inputs
    visit_input_values(self.inputs, values, callback)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/parameters/__init__.py", line 168, in visit_input_values
    visit_input_values(input.inputs, values, callback, new_name_prefix, label_prefix, parent_prefix=name_prefix, **payload)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/parameters/__init__.py", line 170, in visit_input_values
    callback_helper(input, input_values, name_prefix, label_prefix, parent_prefix=parent_prefix, context=context)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/parameters/__init__.py", line 131, in callback_helper
    new_value = callback(**args)
  File "/mnt/volume/shared/galaxy/server/lib/galaxy/tools/actions/__init__.py", line 159, in visitor
    target_dict[conversion_name] = conversion_data.id  # a more robust way to determine JSONable value is desired
AttributeError: 'NoneType' object has no attribute 'id'
```

Martin suggested ditching the conversions from CSV to TSV since they are not necessary.
