### PR TITLE
Increased version to 0.9.0

### DIFF
--- a/tools/matchms/matchms.xml
+++ b/tools/matchms/matchms.xml
@@ -1,6 +1,6 @@
-<tool id="matchms" name="matchMS" version="0.8.2+galaxy3">
+<tool id="matchms" name="matchMS" version="0.9.0+galaxy0">
     <requirements>
-        <requirement type="package" version="0.8.2">matchms</requirement>
+        <requirement type="package" version="0.9.0">matchms</requirement>
         <requirement type="package" version="1.1.4">pandas</requirement>
     </requirements>
 


### PR DESCRIPTION
Increased matchMS version to 0.9.0. This is a first step to also include the ModifiedCosine metric.

Planemo tests all pass.