### PR TITLE
188 tabular formats

### DIFF
--- a/tools/matchms/formatter.py
+++ b/tools/matchms/formatter.py
@@ -113,8 +113,11 @@ def get_top_k_data(ctx, k):
 
 @cli.resultcallback()
 def write_output(result: DataFrame, scores_filename, matches_filename, output_filename):
+    input_file = read_csv(scores_filename, sep=None, iterator=True)
+    sep = input_file._engine.data.dialect.delimiter
+
     result = result.reset_index().rename(columns={'level_0': 'query', 'compound': 'reference'})
-    result.to_csv(output_filename, sep="\t", index=False)
+    result.to_csv(output_filename, sep=sep, index=False)
 
 
 if __name__ == '__main__':

--- a/tools/matchms/formatter.py
+++ b/tools/matchms/formatter.py
@@ -73,8 +73,8 @@ def load_data(scores_filename: str, matches_filename: str) -> DataFrame:
     Returns:
         DataFrame: Joined dataframe on compounds containing scores an matches in long format.
     """
-    matches = read_csv(matches_filename, sep='\t', index_col=0)
-    scores = read_csv(scores_filename, sep='\t', index_col=0)
+    matches = read_csv(matches_filename, sep=None, index_col=0)
+    scores = read_csv(scores_filename, sep=None, index_col=0)
 
     scores_long = create_long_table(scores, 'score')
     matches_long = create_long_table(matches, 'matches')

--- a/tools/matchms/matchms_formatter.xml
+++ b/tools/matchms/matchms_formatter.xml
@@ -31,8 +31,8 @@
     </configfiles>
 
     <inputs>
-        <param label="Scores Table" name="scores" type="data" format="tsv" help="Scores output table." />
-        <param label="Matches Table" name="matches" type="data" format="tsv" help="Scores output table." />
+        <param label="Scores Table" name="scores" type="data" format="table,csv,tsv" help="Scores output table." />
+        <param label="Matches Table" name="matches" type="data" format="table,csv,tsv" help="Scores output table." />
 
         <conditional name="method">
             <param name="selection" type="select" label="Formatting method">
@@ -52,7 +52,7 @@
 
     </inputs>
     <outputs>
-        <data label="${tool.name} (${method.selection}) on ${on_string}" name="output" format="tsv" />
+        <data label="${tool.name} (${method.selection}) on ${on_string}" name="output" format_source="scores" metadata_source="scores" />
     </outputs>
 
     <tests>

--- a/tools/matchms/matchms_formatter.xml
+++ b/tools/matchms/matchms_formatter.xml
@@ -31,8 +31,8 @@
     </configfiles>
 
     <inputs>
-        <param label="Scores Table" name="scores" type="data" format="table,csv,tsv" help="Scores output table." />
-        <param label="Matches Table" name="matches" type="data" format="table,csv,tsv" help="Scores output table." />
+        <param label="Scores Table" name="scores" type="data" format="csv,tsv" help="Scores output table." />
+        <param label="Matches Table" name="matches" type="data" format="csv,tsv" help="Scores output table." />
 
         <conditional name="method">
             <param name="selection" type="select" label="Formatting method">
@@ -52,7 +52,7 @@
 
     </inputs>
     <outputs>
-        <data label="${tool.name} (${method.selection}) on ${on_string}" name="output" format_source="scores" metadata_source="scores" />
+        <data label="${tool.name} (${method.selection}) on ${on_string}" name="output" format_source="scores" />
     </outputs>
 
     <tests>


### PR DESCRIPTION
PR to support multiple tabular formats in `matchms_formatter`.
For now, `.tsv` and `.csv` formats are allowed.
This required to change both Galaxy tool wrapper to accept these formats and reading of the fils using `pandas.read_csv` function.

Close #188.
