### PR TITLE
Update RAMClustR to version 1.2.4

### DIFF
--- a/tools/ramclustr/macros.xml
+++ b/tools/ramclustr/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.2.2</token>
+    <token name="@TOOL_VERSION@">1.2.4</token>
 
     <xml name="creator">
         <creator>


### PR DESCRIPTION
Bump version of `RAMClustR` to `v1.2.4`.
Close #253.