### PR TITLE
MSME matchms logging level

### DIFF
--- a/tools/msmetaenhancer/msmetaenhancer.xml
+++ b/tools/msmetaenhancer/msmetaenhancer.xml
@@ -8,7 +8,6 @@
 
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">msmetaenhancer</requirement>
-        <requirement type="package" version="0.14.0">matchms</requirement>
     </requirements>
 
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/msmetaenhancer/msmetaenhancer.xml
+++ b/tools/msmetaenhancer/msmetaenhancer.xml
@@ -1,4 +1,4 @@
-<tool id="msmetaenhancer" name="MSMetaEnhancer" version="@TOOL_VERSION@+galaxy0">
+<tool id="msmetaenhancer" name="MSMetaEnhancer" version="@TOOL_VERSION@+galaxy1">
     <description>annotate MS data</description>
 
     <macros>

--- a/tools/msmetaenhancer/msmetaenhancer.xml
+++ b/tools/msmetaenhancer/msmetaenhancer.xml
@@ -8,6 +8,7 @@
 
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">msmetaenhancer</requirement>
+        <requirement type="package" version="0.14.0">matchms</requirement>
     </requirements>
 
     <command detect_errors="exit_code"><![CDATA[

--- a/tools/msmetaenhancer/msmetaenhancer_wrapper.py
+++ b/tools/msmetaenhancer/msmetaenhancer_wrapper.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import sys
+
 from matchms import set_matchms_logger_level
 from MSMetaEnhancer import Application
 

--- a/tools/msmetaenhancer/msmetaenhancer_wrapper.py
+++ b/tools/msmetaenhancer/msmetaenhancer_wrapper.py
@@ -1,8 +1,7 @@
 import argparse
 import asyncio
 import sys
-
-
+from matchms import set_matchms_logger_level
 from MSMetaEnhancer import Application
 
 
@@ -16,6 +15,8 @@ def main(argv):
 
     app = Application(log_file=args.log_file)
 
+    # set matchms logging level to avoid extensive messages in stdout
+    set_matchms_logger_level("ERROR")
     # import .msp file
     app.load_spectra(args.input_file, file_format='msp')
 

--- a/tools/msmetaenhancer/msmetaenhancer_wrapper.py
+++ b/tools/msmetaenhancer/msmetaenhancer_wrapper.py
@@ -16,10 +16,13 @@ def main(argv):
 
     app = Application(log_file=args.log_file)
 
-    # set matchms logging level to avoid extensive messages in stdout
+    # set matchms logging level to avoid extensive messages in stdout while reading file
     set_matchms_logger_level("ERROR")
     # import .msp file
     app.load_spectra(args.input_file, file_format='msp')
+
+    # set matchms logging level back to warning
+    set_matchms_logger_level("WARNING")
 
     # curate given metadata
     app.curate_spectra()


### PR DESCRIPTION
Set `matchms` logging level to `ERROR` to avoid extensive messages in stdout. This required to add `matchms` as MSME wrapper dependency.

Close #255.