### PR TITLE
Update R lint action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -169,7 +169,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - uses: r-lib/actions/setup-r@master
+    - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.r-version }}
     - name: Cache R packages


### PR DESCRIPTION
Action `r-lib/actions@master` is not longer available, version `r-lib/actions/setup-r@v2` is [recommended](https://github.com/r-lib/actions).