### PR TITLE
MSMetaEnhancer: get rid of Fontconfig error

### DIFF
--- a/tools/msmetaenhancer/msmetaenhancer.xml
+++ b/tools/msmetaenhancer/msmetaenhancer.xml
@@ -1,4 +1,4 @@
-<tool id="msmetaenhancer" name="MSMetaEnhancer" version="@TOOL_VERSION@+galaxy1">
+<tool id="msmetaenhancer" name="MSMetaEnhancer" version="@TOOL_VERSION@+galaxy2">
     <description>annotate MS data</description>
 
     <macros>

--- a/tools/msmetaenhancer/msmetaenhancer.xml
+++ b/tools/msmetaenhancer/msmetaenhancer.xml
@@ -10,6 +10,11 @@
         <requirement type="package" version="@TOOL_VERSION@">msmetaenhancer</requirement>
     </requirements>
 
+    <environment_variables>
+        <environment_variable name="MPLCONFIGDIR">\$_GALAXY_JOB_TMP_DIR</environment_variable>
+        <environment_variable name="XDG_CACHE_HOME">\$_GALAXY_JOB_TMP_DIR</environment_variable>
+    </environment_variables>
+
     <command detect_errors="exit_code"><![CDATA[
         sh ${msmetaenhancer_python_cli}
     ]]> </command>


### PR DESCRIPTION
Set environment variables for caching for `MSMetaEnhancer` to remove `Fontconfig error` and Matplotlib warning.

Close #312.