### PR TITLE
Bump biotransformer to version 3.0_20230403

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -1,4 +1,3 @@
-tools/biotransformer
 tools/export_to_path
 tools/retip
 tools/october_recetox_xmsannotator

--- a/tools/biotransformer/biotransformer.xml
+++ b/tools/biotransformer/biotransformer.xml
@@ -1,4 +1,4 @@
-<tool id="biotransformer" name="BioTransformer" version="@TOOL_VERSION@+galaxy0">
+<tool id="biotransformer" name="BioTransformer" version="@TOOL_VERSION@+galaxy0" profile="23.00">
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/biotransformer/biotransformer.xml
+++ b/tools/biotransformer/biotransformer.xml
@@ -1,4 +1,4 @@
-<tool id="biotransformer" name="BioTransformer" version="@TOOL_VERSION@+galaxy0" profile="23.00">
+<tool id="biotransformer" name="BioTransformer" version="@TOOL_VERSION@+galaxy0" profile="21.09">
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/biotransformer/biotransformer.xml
+++ b/tools/biotransformer/biotransformer.xml
@@ -1,4 +1,4 @@
-<tool id="biotransformer" name="BioTransformer" version="@TOOL_VERSION@+galaxy1">
+<tool id="biotransformer" name="BioTransformer" version="@TOOL_VERSION@+galaxy0">
     <macros>
         <import>macros.xml</import>
     </macros>

--- a/tools/biotransformer/macros.xml
+++ b/tools/biotransformer/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">3.0</token>
+    <token name="@TOOL_VERSION@">3.0_20230403</token>
     <xml name="creator">
         <creator>
             <person

--- a/tools/biotransformer/test-data/output1.tsv
+++ b/tools/biotransformer/test-data/output1.tsv
@@ -1,9 +1,9 @@
 	SMILES query	SMILES target	InChI	InChIKey	SMILES	Synonyms	PUBCHEM_CID	Molecular formula	Major Isotope Mass	ALogP	Lipinski_Violations	Insecticide_Likeness_Violations	Post_Em_Herbicide_Likeness_Violations	Metabolite ID	cdk:Title	Reaction	Reaction ID	Enzyme(s)	Biosystem	Precursor ID	Precursor SMILES	Precursor InChI	Precursor InChIKey	Precursor ALogP	Precursor Major Isotope Mass
 0	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OC1C(C(C(C(C(=O)O)O1)O)O)O	
-"	InChI=1S/C16H22O7/c1-7(2)9-5-4-8(3)6-10(9)22-16-13(19)11(17)12(18)14(23-16)15(20)21/h4-7,11-14,16-19H,1-3H3,(H,20,21)	ADQJSAVCKZSGMK-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC2OC(C(O)C(O)C2O)C(O)=O	"NSC404789
+"	InChI=1S/C16H22O7/c1-7(2)9-5-4-8(3)6-10(9)22-16-13(19)11(17)12(18)14(23-16)15(20)21/h4-7,11-14,16-19H,1-3H3,(H,20,21)	ADQJSAVCKZSGMK-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC2OC(C(O)=O)C(C(C2O)O)O	"NSC404789
 NSC-404789
 (2S,3S,4S,5R)-3,4,5-trihydroxy-6-(5-methyl-2-propan-2-ylphenoxy)oxane-2-carboxylic acid
-3,5-trihydroxy-6-(2-isopropyl-5-methyl-phenoxy)tetrahydro-2H-pyran-2-carboxylic acid"	346530.0	C16H22O7	326.13655304400004	0.6636999999999996	0	1	1	BTM00001	BTM00001	Aromatic OH-glucuronidation	BTMR0166	EC 2.4.1.17	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+3,5-trihydroxy-6-(2-isopropyl-5-methyl-phenoxy)tetrahydro-2H-pyran-2-carboxylic acid"	346530	C16H22O7	326.13655304400004	1.5474999999999992	0	1	1	BTM00001	BTM00001	Aromatic OH-glucuronidation	BTMR0166	EC 2.4.1.17	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
 1	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OS(=O)(=O)O	
 "	InChI=1S/C10H14O4S/c1-7(2)9-5-4-8(3)6-10(9)14-15(11,12)13/h4-7H,1-3H3,(H,11,12,13)	NODSEPOUFZPJEQ-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OS(O)(=O)=O	"thymol sulfate
 Thymol sulphate
@@ -11,47 +11,118 @@ Thymol sulfuric acid
 Thymol sulphuric acid
 SCHEMBL235717
 CHEBI:82911
+(5-methyl-2-propan-2-ylphenyl) hydrogen sulfate
 5-methyl-2-(propan-2-yl)phenyl hydrogen sulfate
-Q27156452"	12456386.0	C10H14O4S	230.061279928	2.0731	0	0	0	BTM00002	BTM00002	3-OH-Sulfonation of phenolic compound	BTMR0196	EC 2.8.2.1	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-2	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(c(c1)O)C(C)(C)O	
-"	InChI=1S/C10H14O2/c1-7-4-5-8(9(11)6-7)10(2,3)12/h4-6,11-12H,1-3H3	UWRRYLNXMGBJKK-UHFFFAOYSA-N	CC(C)(C1=CC=C(C)C=C1O)O	SCHEMBL22652590	11332674.0	C10H14O2	166.099379688	2.0267999999999997	0	0	0	BTM00003	BTM00003	Hydroxylation of penultimate aliphatic carbon adjacent to aromatic carbon	BTMR1076	"CYP1A2
+Q27156452"	12456386	C10H14O4S	230.061279928	2.5061999999999993	0	0	0	BTM00002	BTM00002	Sulfonation of phenolic compound	BTMR1376	EC 2.8.2.1	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+2	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OC	
+"	InChI=1S/C11H16O/c1-8(2)10-6-5-9(3)7-11(10)12-4/h5-8H,1-4H3	LSQXNMXDFRRDSJ-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC	"Thymol methyl ether
+2-Isopropyl-5-methylanisole
+1076-56-8
+O-Methylthymol
+Thymyl methyl ether
+Methyl thymyl ether
+3-Methoxy-p-cymene
+4-Isopropyl-3-methoxytoluene
+1-Isopropyl-2-methoxy-4-methylbenzene
+Methyl thymol ether
+Benzene, 2-methoxy-4-methyl-1-(1-methylethyl)-
+ANISOLE, 2-ISOPROPYL-5-METHYL-
+2-methoxy-4-methyl-1-propan-2-ylbenzene
+1-Methyl-3-methoxy-4-isopropylbenzene
+Benzene,2-methoxy-4-methyl-1-(1-methylethyl)-
+methylthymol
+FEMA No. 3436
+Thymol methyl
+thymol Me ether
+2-Methoxy-4-methyl-1-(1-methylethyl)benzene
+2-methoxy-4-methyl-1-(propan-2-yl)benzene
+Fema3436
+VTE0C4390U
+DTXSID5047617
+NSC-404221
+Methylthymol, o-
+EINECS 214-063-9
+NSC 404221
+BRN 2042889
+UNII-VTE0C4390U
+AI3-03431
+thymyl methyl oxide
+Methyl THYMYL oxide
+starbld0009587
+Thymol derivative, 21
+4-06-00-03335 (Beilstein Handbook Reference)
+3-METHOXY-PARA-CYMENE
+SCHEMBL196752
+2-Isopropyl-5-methyl-Anisole
+CHEMBL2424841
+DTXCID3027617
+CHEBI:167336
+BDBM248170
+Tox21_302575
+MFCD01674973
+NSC404221
+2-ISO PROPYL-5-METHYLANISOLE
+AKOS015914183
+Thymol methyl ether (= methyl thymol)
+NCGC00256877-01
+LS-13985
+CAS-1076-56-8
+CS-0335474
+FT-0754651
+I0996
+1-Methyl-3-methoxy-4-isopropylbenzene, 98%
+D91215
+Q27292012
+1-METHYL-3-METHOXY-4-ISOPROPYL BENZENE [FHFI]
+1-Isopropyl-2-methoxy-4-methylbenzene, analytical standard"	14104	C11H16O	164.120115132	3.493999999999998	0	0	0	BTM00003	BTM00003	Methylation of phenolic compound	BTMR1377	EC 2.1.1.25	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+3	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(c(c1)O)C(C)(C)O	
+"	InChI=1S/C10H14O2/c1-7-4-5-8(9(11)6-7)10(2,3)12/h4-6,11-12H,1-3H3	UWRRYLNXMGBJKK-UHFFFAOYSA-N	CC(C)(C1=CC=C(C)C=C1O)O	"SCHEMBL22652590
+2-(2-hydroxypropan-2-yl)-5-methylphenol
+EN300-1838871
+4478-33-5"	11332674	C10H14O2	166.099379688	2.0267999999999997	0	0	0	BTM00004	BTM00004	Hydroxylation of non-terminal aliphatic carbon adjacent to aromatic ring	BTMR1077	"CYP1A2
 CYP2C8
 CYP2C9
-CYP2C19
-CYP2D6"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-3	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1cc(c(C)cc1O)O	
+CYP2D6
+CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+4	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1cc(c(C)cc1O)O	
 "	InChI=1S/C10H14O2/c1-6(2)8-5-9(11)7(3)4-10(8)12/h4-6,11-12H,1-3H3	OQIOHYHRGZNZCW-UHFFFAOYSA-N	CC(C)C1=CC(=C(C)C=C1O)O	"Thymohydroquinone
-Thymoquinol
-Hydrothymoquinone
 2217-60-9
-1,4-Benzenediol, 2-methyl-5-(1-methylethyl)-
+Hydrothymoquinone
+Thymoquinol
 p-Cymene-2,5-diol
+1,4-Benzenediol, 2-methyl-5-(1-methylethyl)-
 2-Methyl-5-isopropylhydroquinone
 Hydroquinone, 5-isopropyl-2-methyl-
+2-methyl-5-(propan-2-yl)benzene-1,4-diol
 NSC 34803
 2-ISOPROPYL-5-METHYLBENZENE-1,4-DIOL
-UNII-1C2ICM1R8V
 1C2ICM1R8V
 2-methyl-5-(1-methylethyl)-1,4-benzenediol
+NSC-34803
 BRN 2084452
 Thymohydrochinon
-Thymohydroquinone (I)
 2-methyl-5-propan-2-ylbenzene-1,4-diol
+2-hydroxythymol
+2,5-DIHYDROXY-P-CYMENE
+Thymohydroquinone (I)
+UNII-1C2ICM1R8V
 SCHEMBL69082
-p-Cymene-2,5-diol (8CI)
 CHEMBL4204349
+2-isopropyl-5-methylhydroquinone
 DTXSID70176706
 WLN: QR DQ B1 EY1&1
 NSC34803
 1, 2-methyl-5-(1-methylethyl)-
-NSC-34803
 AKOS006274324
-ZINC100292063
-MCULE-6916835293
 2-isopropyl-5-methyl-benzene-1,4-diol
-2-methyl-5-(propan-2-yl)benzene-1,4-diol
+CS-0259073
 FT-0700031
-IMW"	95779.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00004	BTM00004	p-Hydroxylation of phenol	BTMR1038	"CYP1A2
+4-HYDROXY-5-ISOPROPYL-2-METHYLPHENOL
+EN300-722422
+Z1198148655
+2-Methyl-5-(1-Methylethyl)cyclohexa-2,5-Diene-1,4-Dione
+9J9
+IMW"	95779	C10H14O2	166.099379688	2.9756	0	0	0	BTM00005	BTM00005	p-Hydroxylation of phenol	BTMR1038	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -60,12 +131,12 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-4	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(cc1O)CO	
+5	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(cc1O)CO	
 "	InChI=1S/C10H14O2/c1-7(2)9-4-3-8(6-11)5-10(9)12/h3-5,7,11-12H,6H2,1-2H3	UNNQYEJIPIBHFS-UHFFFAOYSA-N	CC(C)C1=CC=C(CO)C=C1O	"77311-68-3
+5-(Hydroxymethyl)-2-(propan-2-yl)phenol
 5-hydroxymethyl-2-isopropylphenol
 DTXSID70554040
-2-Isopropyl-5-(hydroxymethyl)phenol
-5-(Hydroxymethyl)-2-(propan-2-yl)phenol"	14002478.0	C10H14O2	166.099379688	1.3752000000000006	0	0	0	BTM00005	BTM00005	Aliphatic hydroxylation of methyl carbon adjacent to aromatic ring	BTMR1058	"CYP1A2
+2-Isopropyl-5-(hydroxymethyl)phenol"	14002478	C10H14O2	166.099379688	2.1523000000000003	0	0	0	BTM00006	BTM00006	Aliphatic hydroxylation of methyl carbon adjacent to aromatic ring	BTMR1058	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -74,51 +145,14 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-5	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1c(cc(C)cc1O)O	
-"	InChI=1S/C10H14O2/c1-6(2)10-8(11)4-7(3)5-9(10)12/h4-6,11-12H,1-3H3	TUWRZVAMHVWRER-UHFFFAOYSA-N	CC(C)C1=C(C=C(C)C=C1O)O	SCHEMBL1494319	12310887.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00006	BTM00006	Hydroxylation of benzene on carbon ortho to electron donating group	BTMR1045	"CYP1A2
-CYP2C8
-CYP2C9
-CYP2C19
-CYP2D6
-CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-6	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)c(c1O)O	
-"	InChI=1S/C10H14O2/c1-6(2)8-5-4-7(3)9(11)10(8)12/h4-6,11-12H,1-3H3	LYUBXLHGANLIMX-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C(=C1O)O	"Cymopyrocatechol
-490-06-2
-3-isopropyl-6-methylcatechol
-p-cymene-2,3-diol
-3-Isopropyl-6-methylpyrocatechol
-Pyrocatechol, 2-isopropyl-6-methyl-
-UNII-93XFQ715UL
-93XFQ715UL
-NSC 40567
-3-isopropyl-6-methylbenzene-1,2-diol
-BRN 2248022
-3-Isopropyl-6-Methyl-Benzene-1,2-Diol
-NSC40567
-p-Cymene-2,3-diol (7CI,8CI)
-3-methyl-6-propan-2-ylbenzene-1,2-diol
-SCHEMBL1494556
-1,2-Benzenediol, 3-methyl-6-(1-methylethyl)- (9CI)
-DTXSID10197652
-5722AF
-NSC-40567
-ZINC96035800
-AKOS006275160
-MCULE-2488475103
-3-methyl-6-propan-2-yl-benzene-1,2-diol
-3-methyl-6-(propan-2-yl)benzene-1,2-diol
-A828568"	95873.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00007	BTM00007	Hydroxylation of benzene on carbon ortho to electron donating group	BTMR1045	"CYP1A2
-CYP2C8
-CYP2C9
-CYP2C19
-CYP2D6
-CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-7	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(C(C)CO)c(c1)O	
+6	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(C(C)CO)c(c1)O	
 "	InChI=1S/C10H14O2/c1-7-3-4-9(8(2)6-11)10(12)5-7/h3-5,8,11-12H,6H2,1-2H3	CLJPRXFHCRIUKW-UHFFFAOYSA-N	C(C(C)C1=CC=C(C)C=C1O)O	"9-Hydroxythymol
 61955-76-8
 2-(1-hydroxypropan-2-yl)-5-methylphenol
 p-cymene-3,8-diol
-p-Mentha-1,3,5-triene-3,9-diol"	14432748.0	C10H14O2	166.099379688	1.5777000000000003	0	0	0	BTM00008	BTM00008	Hydroxylation of terminal methyl	BTMR1061	"CYP1A2
+HY-N10925
+p-Mentha-1,3,5-triene-3,9-diol
+CS-0637580"	14432748	C10H14O2	166.099379688	2.0848000000000004	0	0	0	BTM00007	BTM00007	Hydroxylation of terminal methyl	BTMR1061	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -127,11 +161,55 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-8	CC(C)C1=CC=C(C)C=C1O	"CC(C)C1=C(C=C(C)C2C1O2)O	
-"	InChI=1S/C10H14O2/c1-5(2)8-7(11)4-6(3)9-10(8)12-9/h4-5,9-11H,1-3H3	DETRTAMOFLJUIH-UHFFFAOYSA-N	CC(C)C=1C2C(C(C)=CC1O)O2			C10H14O2	166.099379688	0.9412999999999996	0	0	0	BTM00009	BTM00009	Epoxidation of arene	BTMR1028	"CYP1A2
+7	CC(C)C1=CC=C(C)C=C1O	"C=C(C)c1ccc(C)cc1O	
+"	InChI=1S/C10H12O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-6,11H,1H2,2-3H3	IHWFPRKZRRGTTI-UHFFFAOYSA-N	CC(=C)C1=CC=C(C)C=C1O	"8,9-Dehydrothymol
+2-isopropenyl-5-methylphenol
+18612-99-2
+5-methyl-2-prop-1-en-2-ylphenol
+Phenol, 5-methyl-2-(1-methylethenyl)-
+m-Cresol, 6-isopropenyl-
+SCHEMBL686122
+2-Isopropenyl-5-methyl-phenol
+DTXSID60423892
+5-Methyl-2-(1-methylethenyl)phenol
+5-Methyl-2-(prop-1-en-2-yl)phenol"	6429037	C10H12O	148.088815004	3.0469000000000004	0	0	0	BTM00008	BTM00008	Terminal desaturation	BTMR1190	"CYP1A2
+CYP2A6
+CYP2C9
+CYP2D6
+CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+8	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)c(c1O)O	
+"	InChI=1S/C10H14O2/c1-6(2)8-5-4-7(3)9(11)10(8)12/h4-6,11-12H,1-3H3	LYUBXLHGANLIMX-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C(=C1O)O	"Cymopyrocatechol
+490-06-2
+3-Isopropyl-6-methylpyrocatechol
+p-cymene-2,3-diol
+3-isopropyl-6-methylbenzene-1,2-diol
+3-isopropyl-6-methylcatechol
+Pyrocatechol, 2-isopropyl-6-methyl-
+93XFQ715UL
+3-methyl-6-(propan-2-yl)benzene-1,2-diol
+1,2-Benzenediol, 3-methyl-6-(1-methylethyl)-
+NSC-40567
+NSC 40567
+BRN 2248022
+3-methyl-6-propan-2-ylbenzene-1,2-diol
+NSC40567
+UNII-93XFQ715UL
+SCHEMBL1494556
+2,3-DIHYDROXY-P-CYMENE
+DTXSID10197652
+AKOS006275160
+3-isopropyl-6-methyl-1,2-benzenediol
+3-methyl-6-propan-2-yl-benzene-1,2-diol
+CS-0353716
+EN300-1599484
+2,3-DIHYDROXY-4-ISOPROPYL-1-METHYLBENZENE
+A828568
+3-METHYL-6-(1-METHYLETHYL)-1,2-BENZENEDIOL"	95873	C10H14O2	166.099379688	2.9756	0	0	0	BTM00009	BTM00009	O-Hydroxylation of phenol	BTMR1037	"CYP1A2
+CYP2A6
 CYP2B6
 CYP2C8
 CYP2C9
 CYP2C19
+CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044

--- a/tools/biotransformer/test-data/output2.tsv
+++ b/tools/biotransformer/test-data/output2.tsv
@@ -1,9 +1,9 @@
 	SMILES query	SMILES target	InChI	InChIKey	SMILES	Synonyms	PUBCHEM_CID	Molecular formula	Major Isotope Mass	ALogP	Lipinski_Violations	Insecticide_Likeness_Violations	Post_Em_Herbicide_Likeness_Violations	Metabolite ID	cdk:Title	Reaction	Reaction ID	Enzyme(s)	Biosystem	Precursor ID	Precursor SMILES	Precursor InChI	Precursor InChIKey	Precursor ALogP	Precursor Major Isotope Mass
 0	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OC1C(C(C(C(C(=O)O)O1)O)O)O	
-"	InChI=1S/C16H22O7/c1-7(2)9-5-4-8(3)6-10(9)22-16-13(19)11(17)12(18)14(23-16)15(20)21/h4-7,11-14,16-19H,1-3H3,(H,20,21)	ADQJSAVCKZSGMK-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC2OC(C(O)C(O)C2O)C(O)=O	"NSC404789
+"	InChI=1S/C16H22O7/c1-7(2)9-5-4-8(3)6-10(9)22-16-13(19)11(17)12(18)14(23-16)15(20)21/h4-7,11-14,16-19H,1-3H3,(H,20,21)	ADQJSAVCKZSGMK-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC2OC(C(O)=O)C(C(C2O)O)O	"NSC404789
 NSC-404789
 (2S,3S,4S,5R)-3,4,5-trihydroxy-6-(5-methyl-2-propan-2-ylphenoxy)oxane-2-carboxylic acid
-3,5-trihydroxy-6-(2-isopropyl-5-methyl-phenoxy)tetrahydro-2H-pyran-2-carboxylic acid"	346530.0	C16H22O7	326.13655304400004	0.6636999999999996	0	1	1	BTM00001	BTM00001	Aromatic OH-glucuronidation	BTMR0166	EC 2.4.1.17	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+3,5-trihydroxy-6-(2-isopropyl-5-methyl-phenoxy)tetrahydro-2H-pyran-2-carboxylic acid"	346530	C16H22O7	326.13655304400004	1.5474999999999992	0	1	1	BTM00001	BTM00001	Aromatic OH-glucuronidation	BTMR0166	EC 2.4.1.17	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
 1	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OS(=O)(=O)O	
 "	InChI=1S/C10H14O4S/c1-7(2)9-5-4-8(3)6-10(9)14-15(11,12)13/h4-7H,1-3H3,(H,11,12,13)	NODSEPOUFZPJEQ-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OS(O)(=O)=O	"thymol sulfate
 Thymol sulphate
@@ -11,47 +11,118 @@ Thymol sulfuric acid
 Thymol sulphuric acid
 SCHEMBL235717
 CHEBI:82911
+(5-methyl-2-propan-2-ylphenyl) hydrogen sulfate
 5-methyl-2-(propan-2-yl)phenyl hydrogen sulfate
-Q27156452"	12456386.0	C10H14O4S	230.061279928	2.0731	0	0	0	BTM00002	BTM00002	3-OH-Sulfonation of phenolic compound	BTMR0196	EC 2.8.2.1	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-2	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(c(c1)O)C(C)(C)O	
-"	InChI=1S/C10H14O2/c1-7-4-5-8(9(11)6-7)10(2,3)12/h4-6,11-12H,1-3H3	UWRRYLNXMGBJKK-UHFFFAOYSA-N	CC(C)(C1=CC=C(C)C=C1O)O	SCHEMBL22652590	11332674.0	C10H14O2	166.099379688	2.0267999999999997	0	0	0	BTM00003	BTM00003	Hydroxylation of penultimate aliphatic carbon adjacent to aromatic carbon	BTMR1076	"CYP1A2
+Q27156452"	12456386	C10H14O4S	230.061279928	2.5061999999999993	0	0	0	BTM00002	BTM00002	Sulfonation of phenolic compound	BTMR1376	EC 2.8.2.1	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+2	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OC	
+"	InChI=1S/C11H16O/c1-8(2)10-6-5-9(3)7-11(10)12-4/h5-8H,1-4H3	LSQXNMXDFRRDSJ-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC	"Thymol methyl ether
+2-Isopropyl-5-methylanisole
+1076-56-8
+O-Methylthymol
+Thymyl methyl ether
+Methyl thymyl ether
+3-Methoxy-p-cymene
+4-Isopropyl-3-methoxytoluene
+1-Isopropyl-2-methoxy-4-methylbenzene
+Methyl thymol ether
+Benzene, 2-methoxy-4-methyl-1-(1-methylethyl)-
+ANISOLE, 2-ISOPROPYL-5-METHYL-
+2-methoxy-4-methyl-1-propan-2-ylbenzene
+1-Methyl-3-methoxy-4-isopropylbenzene
+Benzene,2-methoxy-4-methyl-1-(1-methylethyl)-
+methylthymol
+FEMA No. 3436
+Thymol methyl
+thymol Me ether
+2-Methoxy-4-methyl-1-(1-methylethyl)benzene
+2-methoxy-4-methyl-1-(propan-2-yl)benzene
+Fema3436
+VTE0C4390U
+DTXSID5047617
+NSC-404221
+Methylthymol, o-
+EINECS 214-063-9
+NSC 404221
+BRN 2042889
+UNII-VTE0C4390U
+AI3-03431
+thymyl methyl oxide
+Methyl THYMYL oxide
+starbld0009587
+Thymol derivative, 21
+4-06-00-03335 (Beilstein Handbook Reference)
+3-METHOXY-PARA-CYMENE
+SCHEMBL196752
+2-Isopropyl-5-methyl-Anisole
+CHEMBL2424841
+DTXCID3027617
+CHEBI:167336
+BDBM248170
+Tox21_302575
+MFCD01674973
+NSC404221
+2-ISO PROPYL-5-METHYLANISOLE
+AKOS015914183
+Thymol methyl ether (= methyl thymol)
+NCGC00256877-01
+LS-13985
+CAS-1076-56-8
+CS-0335474
+FT-0754651
+I0996
+1-Methyl-3-methoxy-4-isopropylbenzene, 98%
+D91215
+Q27292012
+1-METHYL-3-METHOXY-4-ISOPROPYL BENZENE [FHFI]
+1-Isopropyl-2-methoxy-4-methylbenzene, analytical standard"	14104	C11H16O	164.120115132	3.493999999999998	0	0	0	BTM00003	BTM00003	Methylation of phenolic compound	BTMR1377	EC 2.1.1.25	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+3	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(c(c1)O)C(C)(C)O	
+"	InChI=1S/C10H14O2/c1-7-4-5-8(9(11)6-7)10(2,3)12/h4-6,11-12H,1-3H3	UWRRYLNXMGBJKK-UHFFFAOYSA-N	CC(C)(C1=CC=C(C)C=C1O)O	"SCHEMBL22652590
+2-(2-hydroxypropan-2-yl)-5-methylphenol
+EN300-1838871
+4478-33-5"	11332674	C10H14O2	166.099379688	2.0267999999999997	0	0	0	BTM00004	BTM00004	Hydroxylation of non-terminal aliphatic carbon adjacent to aromatic ring	BTMR1077	"CYP1A2
 CYP2C8
 CYP2C9
-CYP2C19
-CYP2D6"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-3	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1cc(c(C)cc1O)O	
+CYP2D6
+CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+4	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1cc(c(C)cc1O)O	
 "	InChI=1S/C10H14O2/c1-6(2)8-5-9(11)7(3)4-10(8)12/h4-6,11-12H,1-3H3	OQIOHYHRGZNZCW-UHFFFAOYSA-N	CC(C)C1=CC(=C(C)C=C1O)O	"Thymohydroquinone
-Thymoquinol
-Hydrothymoquinone
 2217-60-9
-1,4-Benzenediol, 2-methyl-5-(1-methylethyl)-
+Hydrothymoquinone
+Thymoquinol
 p-Cymene-2,5-diol
+1,4-Benzenediol, 2-methyl-5-(1-methylethyl)-
 2-Methyl-5-isopropylhydroquinone
 Hydroquinone, 5-isopropyl-2-methyl-
+2-methyl-5-(propan-2-yl)benzene-1,4-diol
 NSC 34803
 2-ISOPROPYL-5-METHYLBENZENE-1,4-DIOL
-UNII-1C2ICM1R8V
 1C2ICM1R8V
 2-methyl-5-(1-methylethyl)-1,4-benzenediol
+NSC-34803
 BRN 2084452
 Thymohydrochinon
-Thymohydroquinone (I)
 2-methyl-5-propan-2-ylbenzene-1,4-diol
+2-hydroxythymol
+2,5-DIHYDROXY-P-CYMENE
+Thymohydroquinone (I)
+UNII-1C2ICM1R8V
 SCHEMBL69082
-p-Cymene-2,5-diol (8CI)
 CHEMBL4204349
+2-isopropyl-5-methylhydroquinone
 DTXSID70176706
 WLN: QR DQ B1 EY1&1
 NSC34803
 1, 2-methyl-5-(1-methylethyl)-
-NSC-34803
 AKOS006274324
-ZINC100292063
-MCULE-6916835293
 2-isopropyl-5-methyl-benzene-1,4-diol
-2-methyl-5-(propan-2-yl)benzene-1,4-diol
+CS-0259073
 FT-0700031
-IMW"	95779.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00004	BTM00004	p-Hydroxylation of phenol	BTMR1038	"CYP1A2
+4-HYDROXY-5-ISOPROPYL-2-METHYLPHENOL
+EN300-722422
+Z1198148655
+2-Methyl-5-(1-Methylethyl)cyclohexa-2,5-Diene-1,4-Dione
+9J9
+IMW"	95779	C10H14O2	166.099379688	2.9756	0	0	0	BTM00005	BTM00005	p-Hydroxylation of phenol	BTMR1038	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -60,12 +131,12 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-4	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(cc1O)CO	
+5	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(cc1O)CO	
 "	InChI=1S/C10H14O2/c1-7(2)9-4-3-8(6-11)5-10(9)12/h3-5,7,11-12H,6H2,1-2H3	UNNQYEJIPIBHFS-UHFFFAOYSA-N	CC(C)C1=CC=C(CO)C=C1O	"77311-68-3
+5-(Hydroxymethyl)-2-(propan-2-yl)phenol
 5-hydroxymethyl-2-isopropylphenol
 DTXSID70554040
-2-Isopropyl-5-(hydroxymethyl)phenol
-5-(Hydroxymethyl)-2-(propan-2-yl)phenol"	14002478.0	C10H14O2	166.099379688	1.3752000000000006	0	0	0	BTM00005	BTM00005	Aliphatic hydroxylation of methyl carbon adjacent to aromatic ring	BTMR1058	"CYP1A2
+2-Isopropyl-5-(hydroxymethyl)phenol"	14002478	C10H14O2	166.099379688	2.1523000000000003	0	0	0	BTM00006	BTM00006	Aliphatic hydroxylation of methyl carbon adjacent to aromatic ring	BTMR1058	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -74,51 +145,14 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-5	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1c(cc(C)cc1O)O	
-"	InChI=1S/C10H14O2/c1-6(2)10-8(11)4-7(3)5-9(10)12/h4-6,11-12H,1-3H3	TUWRZVAMHVWRER-UHFFFAOYSA-N	CC(C)C1=C(C=C(C)C=C1O)O	SCHEMBL1494319	12310887.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00006	BTM00006	Hydroxylation of benzene on carbon ortho to electron donating group	BTMR1045	"CYP1A2
-CYP2C8
-CYP2C9
-CYP2C19
-CYP2D6
-CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-6	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)c(c1O)O	
-"	InChI=1S/C10H14O2/c1-6(2)8-5-4-7(3)9(11)10(8)12/h4-6,11-12H,1-3H3	LYUBXLHGANLIMX-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C(=C1O)O	"Cymopyrocatechol
-490-06-2
-3-isopropyl-6-methylcatechol
-p-cymene-2,3-diol
-3-Isopropyl-6-methylpyrocatechol
-Pyrocatechol, 2-isopropyl-6-methyl-
-UNII-93XFQ715UL
-93XFQ715UL
-NSC 40567
-3-isopropyl-6-methylbenzene-1,2-diol
-BRN 2248022
-3-Isopropyl-6-Methyl-Benzene-1,2-Diol
-NSC40567
-p-Cymene-2,3-diol (7CI,8CI)
-3-methyl-6-propan-2-ylbenzene-1,2-diol
-SCHEMBL1494556
-1,2-Benzenediol, 3-methyl-6-(1-methylethyl)- (9CI)
-DTXSID10197652
-5722AF
-NSC-40567
-ZINC96035800
-AKOS006275160
-MCULE-2488475103
-3-methyl-6-propan-2-yl-benzene-1,2-diol
-3-methyl-6-(propan-2-yl)benzene-1,2-diol
-A828568"	95873.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00007	BTM00007	Hydroxylation of benzene on carbon ortho to electron donating group	BTMR1045	"CYP1A2
-CYP2C8
-CYP2C9
-CYP2C19
-CYP2D6
-CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-7	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(C(C)CO)c(c1)O	
+6	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(C(C)CO)c(c1)O	
 "	InChI=1S/C10H14O2/c1-7-3-4-9(8(2)6-11)10(12)5-7/h3-5,8,11-12H,6H2,1-2H3	CLJPRXFHCRIUKW-UHFFFAOYSA-N	C(C(C)C1=CC=C(C)C=C1O)O	"9-Hydroxythymol
 61955-76-8
 2-(1-hydroxypropan-2-yl)-5-methylphenol
 p-cymene-3,8-diol
-p-Mentha-1,3,5-triene-3,9-diol"	14432748.0	C10H14O2	166.099379688	1.5777000000000003	0	0	0	BTM00008	BTM00008	Hydroxylation of terminal methyl	BTMR1061	"CYP1A2
+HY-N10925
+p-Mentha-1,3,5-triene-3,9-diol
+CS-0637580"	14432748	C10H14O2	166.099379688	2.0848000000000004	0	0	0	BTM00007	BTM00007	Hydroxylation of terminal methyl	BTMR1061	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -127,11 +161,55 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-8	CC(C)C1=CC=C(C)C=C1O	"CC(C)C1=C(C=C(C)C2C1O2)O	
-"	InChI=1S/C10H14O2/c1-5(2)8-7(11)4-6(3)9-10(8)12-9/h4-5,9-11H,1-3H3	DETRTAMOFLJUIH-UHFFFAOYSA-N	CC(C)C=1C2C(C(C)=CC1O)O2			C10H14O2	166.099379688	0.9412999999999996	0	0	0	BTM00009	BTM00009	Epoxidation of arene	BTMR1028	"CYP1A2
+7	CC(C)C1=CC=C(C)C=C1O	"C=C(C)c1ccc(C)cc1O	
+"	InChI=1S/C10H12O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-6,11H,1H2,2-3H3	IHWFPRKZRRGTTI-UHFFFAOYSA-N	CC(=C)C1=CC=C(C)C=C1O	"8,9-Dehydrothymol
+2-isopropenyl-5-methylphenol
+18612-99-2
+5-methyl-2-prop-1-en-2-ylphenol
+Phenol, 5-methyl-2-(1-methylethenyl)-
+m-Cresol, 6-isopropenyl-
+SCHEMBL686122
+2-Isopropenyl-5-methyl-phenol
+DTXSID60423892
+5-Methyl-2-(1-methylethenyl)phenol
+5-Methyl-2-(prop-1-en-2-yl)phenol"	6429037	C10H12O	148.088815004	3.0469000000000004	0	0	0	BTM00008	BTM00008	Terminal desaturation	BTMR1190	"CYP1A2
+CYP2A6
+CYP2C9
+CYP2D6
+CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+8	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)c(c1O)O	
+"	InChI=1S/C10H14O2/c1-6(2)8-5-4-7(3)9(11)10(8)12/h4-6,11-12H,1-3H3	LYUBXLHGANLIMX-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C(=C1O)O	"Cymopyrocatechol
+490-06-2
+3-Isopropyl-6-methylpyrocatechol
+p-cymene-2,3-diol
+3-isopropyl-6-methylbenzene-1,2-diol
+3-isopropyl-6-methylcatechol
+Pyrocatechol, 2-isopropyl-6-methyl-
+93XFQ715UL
+3-methyl-6-(propan-2-yl)benzene-1,2-diol
+1,2-Benzenediol, 3-methyl-6-(1-methylethyl)-
+NSC-40567
+NSC 40567
+BRN 2248022
+3-methyl-6-propan-2-ylbenzene-1,2-diol
+NSC40567
+UNII-93XFQ715UL
+SCHEMBL1494556
+2,3-DIHYDROXY-P-CYMENE
+DTXSID10197652
+AKOS006275160
+3-isopropyl-6-methyl-1,2-benzenediol
+3-methyl-6-propan-2-yl-benzene-1,2-diol
+CS-0353716
+EN300-1599484
+2,3-DIHYDROXY-4-ISOPROPYL-1-METHYLBENZENE
+A828568
+3-METHYL-6-(1-METHYLETHYL)-1,2-BENZENEDIOL"	95873	C10H14O2	166.099379688	2.9756	0	0	0	BTM00009	BTM00009	O-Hydroxylation of phenol	BTMR1037	"CYP1A2
+CYP2A6
 CYP2B6
 CYP2C8
 CYP2C9
 CYP2C19
+CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044

--- a/tools/biotransformer/test-data/output3.tsv
+++ b/tools/biotransformer/test-data/output3.tsv
@@ -1,9 +1,9 @@
 	SMILES query	SMILES target	InChI	InChIKey	SMILES	Synonyms	PUBCHEM_CID	Molecular formula	Major Isotope Mass	ALogP	Lipinski_Violations	Insecticide_Likeness_Violations	Post_Em_Herbicide_Likeness_Violations	Metabolite ID	cdk:Title	Reaction	Reaction ID	Enzyme(s)	Biosystem	Precursor ID	Precursor SMILES	Precursor InChI	Precursor InChIKey	Precursor ALogP	Precursor Major Isotope Mass
 0	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OC1C(C(C(C(C(=O)O)O1)O)O)O	
-"	InChI=1S/C16H22O7/c1-7(2)9-5-4-8(3)6-10(9)22-16-13(19)11(17)12(18)14(23-16)15(20)21/h4-7,11-14,16-19H,1-3H3,(H,20,21)	ADQJSAVCKZSGMK-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC2OC(C(O)C(O)C2O)C(O)=O	"NSC404789
+"	InChI=1S/C16H22O7/c1-7(2)9-5-4-8(3)6-10(9)22-16-13(19)11(17)12(18)14(23-16)15(20)21/h4-7,11-14,16-19H,1-3H3,(H,20,21)	ADQJSAVCKZSGMK-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC2OC(C(O)=O)C(C(C2O)O)O	"NSC404789
 NSC-404789
 (2S,3S,4S,5R)-3,4,5-trihydroxy-6-(5-methyl-2-propan-2-ylphenoxy)oxane-2-carboxylic acid
-3,5-trihydroxy-6-(2-isopropyl-5-methyl-phenoxy)tetrahydro-2H-pyran-2-carboxylic acid"	346530.0	C16H22O7	326.13655304400004	0.6636999999999996	0	1	1	BTM00001	BTM00001	Aromatic OH-glucuronidation	BTMR0166	EC 2.4.1.17	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+3,5-trihydroxy-6-(2-isopropyl-5-methyl-phenoxy)tetrahydro-2H-pyran-2-carboxylic acid"	346530	C16H22O7	326.13655304400004	1.5474999999999992	0	1	1	BTM00001	BTM00001	Aromatic OH-glucuronidation	BTMR0166	EC 2.4.1.17	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
 1	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OS(=O)(=O)O	
 "	InChI=1S/C10H14O4S/c1-7(2)9-5-4-8(3)6-10(9)14-15(11,12)13/h4-7H,1-3H3,(H,11,12,13)	NODSEPOUFZPJEQ-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OS(O)(=O)=O	"thymol sulfate
 Thymol sulphate
@@ -11,47 +11,118 @@ Thymol sulfuric acid
 Thymol sulphuric acid
 SCHEMBL235717
 CHEBI:82911
+(5-methyl-2-propan-2-ylphenyl) hydrogen sulfate
 5-methyl-2-(propan-2-yl)phenyl hydrogen sulfate
-Q27156452"	12456386.0	C10H14O4S	230.061279928	2.0731	0	0	0	BTM00002	BTM00002	3-OH-Sulfonation of phenolic compound	BTMR0196	EC 2.8.2.1	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-2	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(c(c1)O)C(C)(C)O	
-"	InChI=1S/C10H14O2/c1-7-4-5-8(9(11)6-7)10(2,3)12/h4-6,11-12H,1-3H3	UWRRYLNXMGBJKK-UHFFFAOYSA-N	CC(C)(C1=CC=C(C)C=C1O)O	SCHEMBL22652590	11332674.0	C10H14O2	166.099379688	2.0267999999999997	0	0	0	BTM00003	BTM00003	Hydroxylation of penultimate aliphatic carbon adjacent to aromatic carbon	BTMR1076	"CYP1A2
+Q27156452"	12456386	C10H14O4S	230.061279928	2.5061999999999993	0	0	0	BTM00002	BTM00002	Sulfonation of phenolic compound	BTMR1376	EC 2.8.2.1	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+2	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(C)cc1OC	
+"	InChI=1S/C11H16O/c1-8(2)10-6-5-9(3)7-11(10)12-4/h5-8H,1-4H3	LSQXNMXDFRRDSJ-UHFFFAOYSA-N	CC(C)C1=CC=C(C)C=C1OC	"Thymol methyl ether
+2-Isopropyl-5-methylanisole
+1076-56-8
+O-Methylthymol
+Thymyl methyl ether
+Methyl thymyl ether
+3-Methoxy-p-cymene
+4-Isopropyl-3-methoxytoluene
+1-Isopropyl-2-methoxy-4-methylbenzene
+Methyl thymol ether
+Benzene, 2-methoxy-4-methyl-1-(1-methylethyl)-
+ANISOLE, 2-ISOPROPYL-5-METHYL-
+2-methoxy-4-methyl-1-propan-2-ylbenzene
+1-Methyl-3-methoxy-4-isopropylbenzene
+Benzene,2-methoxy-4-methyl-1-(1-methylethyl)-
+methylthymol
+FEMA No. 3436
+Thymol methyl
+thymol Me ether
+2-Methoxy-4-methyl-1-(1-methylethyl)benzene
+2-methoxy-4-methyl-1-(propan-2-yl)benzene
+Fema3436
+VTE0C4390U
+DTXSID5047617
+NSC-404221
+Methylthymol, o-
+EINECS 214-063-9
+NSC 404221
+BRN 2042889
+UNII-VTE0C4390U
+AI3-03431
+thymyl methyl oxide
+Methyl THYMYL oxide
+starbld0009587
+Thymol derivative, 21
+4-06-00-03335 (Beilstein Handbook Reference)
+3-METHOXY-PARA-CYMENE
+SCHEMBL196752
+2-Isopropyl-5-methyl-Anisole
+CHEMBL2424841
+DTXCID3027617
+CHEBI:167336
+BDBM248170
+Tox21_302575
+MFCD01674973
+NSC404221
+2-ISO PROPYL-5-METHYLANISOLE
+AKOS015914183
+Thymol methyl ether (= methyl thymol)
+NCGC00256877-01
+LS-13985
+CAS-1076-56-8
+CS-0335474
+FT-0754651
+I0996
+1-Methyl-3-methoxy-4-isopropylbenzene, 98%
+D91215
+Q27292012
+1-METHYL-3-METHOXY-4-ISOPROPYL BENZENE [FHFI]
+1-Isopropyl-2-methoxy-4-methylbenzene, analytical standard"	14104	C11H16O	164.120115132	3.493999999999998	0	0	0	BTM00003	BTM00003	Methylation of phenolic compound	BTMR1377	EC 2.1.1.25	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+3	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(c(c1)O)C(C)(C)O	
+"	InChI=1S/C10H14O2/c1-7-4-5-8(9(11)6-7)10(2,3)12/h4-6,11-12H,1-3H3	UWRRYLNXMGBJKK-UHFFFAOYSA-N	CC(C)(C1=CC=C(C)C=C1O)O	"SCHEMBL22652590
+2-(2-hydroxypropan-2-yl)-5-methylphenol
+EN300-1838871
+4478-33-5"	11332674	C10H14O2	166.099379688	2.0267999999999997	0	0	0	BTM00004	BTM00004	Hydroxylation of non-terminal aliphatic carbon adjacent to aromatic ring	BTMR1077	"CYP1A2
 CYP2C8
 CYP2C9
-CYP2C19
-CYP2D6"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-3	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1cc(c(C)cc1O)O	
+CYP2D6
+CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
+4	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1cc(c(C)cc1O)O	
 "	InChI=1S/C10H14O2/c1-6(2)8-5-9(11)7(3)4-10(8)12/h4-6,11-12H,1-3H3	OQIOHYHRGZNZCW-UHFFFAOYSA-N	CC(C)C1=CC(=C(C)C=C1O)O	"Thymohydroquinone
-Thymoquinol
-Hydrothymoquinone
 2217-60-9
-1,4-Benzenediol, 2-methyl-5-(1-methylethyl)-
+Hydrothymoquinone
+Thymoquinol
 p-Cymene-2,5-diol
+1,4-Benzenediol, 2-methyl-5-(1-methylethyl)-
 2-Methyl-5-isopropylhydroquinone
 Hydroquinone, 5-isopropyl-2-methyl-
+2-methyl-5-(propan-2-yl)benzene-1,4-diol
 NSC 34803
 2-ISOPROPYL-5-METHYLBENZENE-1,4-DIOL
-UNII-1C2ICM1R8V
 1C2ICM1R8V
 2-methyl-5-(1-methylethyl)-1,4-benzenediol
+NSC-34803
 BRN 2084452
 Thymohydrochinon
-Thymohydroquinone (I)
 2-methyl-5-propan-2-ylbenzene-1,4-diol
+2-hydroxythymol
+2,5-DIHYDROXY-P-CYMENE
+Thymohydroquinone (I)
+UNII-1C2ICM1R8V
 SCHEMBL69082
-p-Cymene-2,5-diol (8CI)
 CHEMBL4204349
+2-isopropyl-5-methylhydroquinone
 DTXSID70176706
 WLN: QR DQ B1 EY1&1
 NSC34803
 1, 2-methyl-5-(1-methylethyl)-
-NSC-34803
 AKOS006274324
-ZINC100292063
-MCULE-6916835293
 2-isopropyl-5-methyl-benzene-1,4-diol
-2-methyl-5-(propan-2-yl)benzene-1,4-diol
+CS-0259073
 FT-0700031
-IMW"	95779.0	C10H14O2	166.099379688	2.198500000000001	0	0	0	BTM00004	BTM00004	p-Hydroxylation of phenol	BTMR1038	"CYP1A2
+4-HYDROXY-5-ISOPROPYL-2-METHYLPHENOL
+EN300-722422
+Z1198148655
+2-Methyl-5-(1-Methylethyl)cyclohexa-2,5-Diene-1,4-Dione
+9J9
+IMW"	95779	C10H14O2	166.099379688	2.9756	0	0	0	BTM00005	BTM00005	p-Hydroxylation of phenol	BTMR1038	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -60,12 +131,12 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-4	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(cc1O)CO	
+5	CC(C)C1=CC=C(C)C=C1O	"CC(C)c1ccc(cc1O)CO	
 "	InChI=1S/C10H14O2/c1-7(2)9-4-3-8(6-11)5-10(9)12/h3-5,7,11-12H,6H2,1-2H3	UNNQYEJIPIBHFS-UHFFFAOYSA-N	CC(C)C1=CC=C(CO)C=C1O	"77311-68-3
+5-(Hydroxymethyl)-2-(propan-2-yl)phenol
 5-hydroxymethyl-2-isopropylphenol
 DTXSID70554040
-2-Isopropyl-5-(hydroxymethyl)phenol
-5-(Hydroxymethyl)-2-(propan-2-yl)phenol"	14002478.0	C10H14O2	166.099379688	1.3752000000000006	0	0	0	BTM00005	BTM00005	Aliphatic hydroxylation of methyl carbon adjacent to aromatic ring	BTMR1058	"CYP1A2
+2-Isopropyl-5-(hydroxymethyl)phenol"	14002478	C10H14O2	166.099379688	2.1523000000000003	0	0	0	BTM00006	BTM00006	Aliphatic hydroxylation of methyl carbon adjacent to aromatic ring	BTMR1058	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -74,12 +145,14 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-7	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(C(C)CO)c(c1)O	
+6	CC(C)C1=CC=C(C)C=C1O	"Cc1ccc(C(C)CO)c(c1)O	
 "	InChI=1S/C10H14O2/c1-7-3-4-9(8(2)6-11)10(12)5-7/h3-5,8,11-12H,6H2,1-2H3	CLJPRXFHCRIUKW-UHFFFAOYSA-N	C(C(C)C1=CC=C(C)C=C1O)O	"9-Hydroxythymol
 61955-76-8
 2-(1-hydroxypropan-2-yl)-5-methylphenol
 p-cymene-3,8-diol
-p-Mentha-1,3,5-triene-3,9-diol"	14432748.0	C10H14O2	166.099379688	1.5777000000000003	0	0	0	BTM00008	BTM00008	Hydroxylation of terminal methyl	BTMR1061	"CYP1A2
+HY-N10925
+p-Mentha-1,3,5-triene-3,9-diol
+CS-0637580"	14432748	C10H14O2	166.099379688	2.0848000000000004	0	0	0	BTM00007	BTM00007	Hydroxylation of terminal methyl	BTMR1061	"CYP1A2
 CYP2A6
 CYP2B6
 CYP2C8
@@ -88,11 +161,19 @@ CYP2C19
 CYP2D6
 CYP2E1
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044
-8	CC(C)C1=CC=C(C)C=C1O	"CC(C)C1=C(C=C(C)C2C1O2)O	
-"	InChI=1S/C10H14O2/c1-5(2)8-7(11)4-6(3)9-10(8)12-9/h4-5,9-11H,1-3H3	DETRTAMOFLJUIH-UHFFFAOYSA-N	CC(C)C=1C2C(C(C)=CC1O)O2			C10H14O2	166.099379688	0.9412999999999996	0	0	0	BTM00009	BTM00009	Epoxidation of arene	BTMR1028	"CYP1A2
-CYP2B6
-CYP2C8
+7	CC(C)C1=CC=C(C)C=C1O	"C=C(C)c1ccc(C)cc1O	
+"	InChI=1S/C10H12O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-6,11H,1H2,2-3H3	IHWFPRKZRRGTTI-UHFFFAOYSA-N	CC(=C)C1=CC=C(C)C=C1O	"8,9-Dehydrothymol
+2-isopropenyl-5-methylphenol
+18612-99-2
+5-methyl-2-prop-1-en-2-ylphenol
+Phenol, 5-methyl-2-(1-methylethenyl)-
+m-Cresol, 6-isopropenyl-
+SCHEMBL686122
+2-Isopropenyl-5-methyl-phenol
+DTXSID60423892
+5-Methyl-2-(1-methylethenyl)phenol
+5-Methyl-2-(prop-1-en-2-yl)phenol"	6429037	C10H12O	148.088815004	3.0469000000000004	0	0	0	BTM00008	BTM00008	Terminal desaturation	BTMR1190	"CYP1A2
+CYP2A6
 CYP2C9
-CYP2C19
-CYP2E1
+CYP2D6
 CYP3A4"	HUMAN	NSC404789	CC(C)C1=CC=C(C)C=C1O	InChI=1S/C10H14O/c1-7(2)9-5-4-8(3)6-10(9)11/h4-7,11H,1-3H3	MGSRCZKZVOBKFT-UHFFFAOYSA-N		150.1044

--- a/tools/biotransformer/wrapper_biotransformer.py
+++ b/tools/biotransformer/wrapper_biotransformer.py
@@ -1,9 +1,9 @@
+import re
 import subprocess
 import sys
 import tempfile
-import re
-import pandas
 
+import pandas
 from openbabel import openbabel, pybel
 openbabel.obErrorLog.StopLogging()
 
@@ -14,7 +14,7 @@ def InchiToSmiles(df):
     for item in df['InChI']:
         tmp = pybel.readstring("inchi", item)
         sm.append(tmp.write("smi"))
-    return(sm)
+    return sm
 
 
 executable = ["biotransformer"]
@@ -64,12 +64,12 @@ smList3 = sum(smList3, [])
 
 out_df1.insert(0, "SMILES query", smList1)
 out_df1.insert(1, "SMILES target", InchiToSmiles(out_df1))
-out_df1.to_csv(ocsv, sep ='\t')
+out_df1.to_csv(ocsv, sep='\t')
 
 out_df2.insert(0, "SMILES query", smList2)
 out_df2.insert(1, "SMILES target", InchiToSmiles(out_df2))
-out_df2.to_csv(ocsv_dup, sep ='\t')
+out_df2.to_csv(ocsv_dup, sep='\t')
 
 out_df3.insert(0, "SMILES query", smList3)
 out_df3.insert(1, "SMILES target", InchiToSmiles(out_df3))
-out_df3.to_csv(ocsv_dup2, sep ='\t')
+out_df3.to_csv(ocsv_dup2, sep='\t')


### PR DESCRIPTION
Bumping biotransformer to version `3.0_20230403` indeed fixes the issue #225 on a global level (does not need to be configured in a particular Galaxy instance).

Close #359.