### PR TITLE
MSMetaEnhancer: Add EDAM identifiers

### DIFF
--- a/tools/msmetaenhancer/msmetaenhancer.xml
+++ b/tools/msmetaenhancer/msmetaenhancer.xml
@@ -1,4 +1,4 @@
-<tool id="msmetaenhancer" name="MSMetaEnhancer" version="@TOOL_VERSION@+galaxy0">
+<tool id="msmetaenhancer" name="MSMetaEnhancer" version="@TOOL_VERSION@+galaxy1">
     <description>annotate MS data</description>
 
     <macros>


### PR DESCRIPTION
Added xref to MSME entry on [bio.tools](https://bio.tools/msmetaenhancer). Galaxy should pull the EDAM operations implicitly from there.

Close #371.