### PR TITLE
RIAssigner: Add EDAM identifiers

### DIFF
--- a/tools/riassigner/riassigner.xml
+++ b/tools/riassigner/riassigner.xml
@@ -1,9 +1,13 @@
-<tool id="riassigner" name="RIAssigner" version="@TOOL_VERSION@+galaxy1" profile="19.05">
+<tool id="riassigner" name="RIAssigner" version="@TOOL_VERSION@+galaxy2" profile="19.05">
     <description>compute retention indices</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="creator"/>
+
+    <xrefs>
+        <xref type="bio.tools">riassigner</xref>
+    </xrefs>
 
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">riassigner</requirement>

--- a/tools/riassigner/riassigner.xml
+++ b/tools/riassigner/riassigner.xml
@@ -1,4 +1,4 @@
-<tool id="riassigner" name="RIAssigner" version="@TOOL_VERSION@+galaxy2" profile="19.05">
+<tool id="riassigner" name="RIAssigner" version="@TOOL_VERSION@+galaxy2" profile="21.09">
     <description>compute retention indices</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
Added xref to RIAssigner entry on [bio.tools](https://bio.tools/riassigner). Galaxy should pull the EDAM operations implicitly from there.

Close https://github.com/RECETOX/galaxytools/issues/373.