### PR TITLE
recetox-aplcms: update to 0.12.0

### DIFF
--- a/tools/recetox_aplcms/macros.xml
+++ b/tools/recetox_aplcms/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.11.0</token>
+    <token name="@TOOL_VERSION@">0.12.0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">r-recetox-aplcms</requirement>

--- a/tools/recetox_aplcms/macros.xml
+++ b/tools/recetox_aplcms/macros.xml
@@ -81,9 +81,9 @@
                         help="The upper limit of the ratio range between the left-standard deviation and the right-standard deviation of the bi-Gaussian function to fit the data." />
             </section>
             <conditional name="sd_cut">
-                <param name="sd_cut_bounds" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Standard deviations boundaries."
-                       help="Do not apply any limitations on the standard deviations." />
-                <when value="FALSE">
+                <param name="sd_cut_bounds" type="boolean" checked="true" truevalue="TRUE" falsevalue="FALSE" label="Standard deviations boundaries."
+                       help="Limit the standard deviations by setting boundaries." />
+                <when value="TRUE">
                     <param name="sd_cut_min" type="float" value="0.01" label="Minimal standard deviation"
                            help="The minimum standard deviation - features with a standard deviation lower than this number are eliminated." />
                     <param name="sd_cut_max" type="float" value="500" label="Maximal standard deviation"

--- a/tools/recetox_aplcms/macros.xml
+++ b/tools/recetox_aplcms/macros.xml
@@ -53,7 +53,7 @@
     </xml>
 
     <xml name="remove_noise_params">
-        <param name="min_pres" type="float" value="0.5" label="Minimal signal presence [fraction of scans]"
+        <param name="min_pres" type="float" value="0.5" label="Minimal signal presence [fraction of scans]" min="0.0" max="1.0"
                help="The minimum proportion of presence in the time period for a series of signals grouped by m/z to be considered a peak." />
         <param name="min_run" type="float" value="12" label="Minimal elution time [unit corresponds to the retention time]"
                help="The minimum length of elution time for a series of signals grouped by m/z to be considered a peak." />

--- a/tools/recetox_aplcms/recetox_aplcms_compute_clusters.xml
+++ b/tools/recetox_aplcms/recetox_aplcms_compute_clusters.xml
@@ -33,6 +33,7 @@
                   rt_tol = $rt_tol
               )
 
+              sample_names <- unlist(lapply(clusters, restore_sample_name))
               save_parquet_collection(clusters, sample_names, "clustered")
          ]]></configfile>
     </configfiles>

--- a/tools/recetox_aplcms/recetox_aplcms_generate_feature_table.xml
+++ b/tools/recetox_aplcms/recetox_aplcms_generate_feature_table.xml
@@ -37,7 +37,7 @@
                  #else:
                  max_bandwidth = NA,
                  #end if
-                 #if $advanced.sd_cut.sd_cut_bounds == "FALSE":
+                 #if $advanced.sd_cut.sd_cut_bounds == "TRUE":
                  sd_cut = c($advanced.sd_cut.sd_cut_min, $advanced.sd_cut.sd_cut_max),
                  #else
                  sd_cut = c(0, Inf),

--- a/tools/recetox_aplcms/recetox_aplcms_merge_known_table.xml
+++ b/tools/recetox_aplcms/recetox_aplcms_merge_known_table.xml
@@ -75,13 +75,13 @@
                 <option value="FALSE">Merge known table to features</option>
             </param>
             <when value="TRUE">
-                <param name="new_feature_min_count" type="integer" value="2" min="1" label="new_feature_min_count"
+                <param name="new_feature_min_count" type="integer" value="2" min="1" label="Minimal occurence of feature"
                        help="The minimum number of occurrences of a historically unseen (unknown) feature to add
                        this feature into the database of known features." />
             </when>
         </conditional>
 
-        <param name="match_tol_ppm" type="integer" optional="true" min="0" label="match_tol_ppm"
+        <param name="match_tol_ppm" type="integer" optional="true" min="0" label="Match tolerance [ppm]"
                help="The ppm tolerance to match identified features to known metabolites/features." />
     </inputs>
 

--- a/tools/recetox_aplcms/utils.R
+++ b/tools/recetox_aplcms/utils.R
@@ -16,6 +16,10 @@ save_sample_name <- function(df, sample_name) {
     return(df)
 }
 
+restore_sample_name <- function(df) {
+    return(df$sample_id[1])
+}
+
 load_sample_name <- function(df) {
     sample_name <- attr(df, "sample_name")
     if (is.null(sample_name)) {


### PR DESCRIPTION
Bump `recetox-aplcms` to version `0.12.0`.

This also covers the issue with the wrong ordering of sample names after the new clustering step #386. 
@hechth can you confirm this is what we wanted?

Also improved some minor issues with the parameters of some of the wrappers #387.

Close #389.