### PR TITLE
Include test-data in .shed.yml for riassigner and recetox_xmsannotator

### DIFF
--- a/tools/recetox_xmsannotator/.shed.yml
+++ b/tools/recetox_xmsannotator/.shed.yml
@@ -10,3 +10,4 @@ repositories:
       - recetox_xmsannotator_advanced.xml
       - macros.xml
       - utils.R
+      - test-data

--- a/tools/riassigner/.shed.yml
+++ b/tools/riassigner/.shed.yml
@@ -10,3 +10,4 @@ repositories:
     include:
       - riassigner.xml
       - macros.xml
+      - test-data


### PR DESCRIPTION
Hi @hechth , we have installed most of the tools on Galaxy Australia but these two failed their tests because test data was missing from the cloned repos on galaxy.