### PR TITLE
Add EDAM identifiers: Retip and recetox-msfinder

### DIFF
--- a/tools/recetox_msfinder/macros.xml
+++ b/tools/recetox_msfinder/macros.xml
@@ -18,6 +18,11 @@
                 name="RECETOX MUNI" />
         </creator>
     </xml>
+    <xml name="refs">
+        <xrefs>
+               <xref type="bio.tools">recetox-msfinder</xref>
+        </xrefs>
+     </xml>
     <xml name="input">
         <param name="input_data" type="data" format="msp" label="Input mass spectral library file to which to add peak annotations."
             help="Formula and InChI (or SMILES) codes are required to be present in the library file" />

--- a/tools/recetox_msfinder/recetox_msfinder.xml
+++ b/tools/recetox_msfinder/recetox_msfinder.xml
@@ -1,8 +1,9 @@
-<tool id="recetox_msfinder" name="RECETOX MsFinder" version="@TOOL_VERSION@+galaxy1">
+<tool id="recetox_msfinder" name="RECETOX MsFinder" version="@TOOL_VERSION@+galaxy2">
     <description>Annotation of fragment peaks in mass spectral libraries.</description>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="refs"/>
     <expand macro="creator" />
 
     <expand macro="requirements" />

--- a/tools/retip/macros.xml
+++ b/tools/retip/macros.xml
@@ -20,6 +20,12 @@
         </creator>
     </xml>
 
+    <xml name="refs">
+        <xrefs>
+               <xref type="bio.tools">retip</xref>
+        </xrefs>
+     </xml>
+
     <xml name="requirements">
         <requirements>
             <container type="docker">recetox/retip:@TOOL_VERSION@-recetox4</container>

--- a/tools/retip/retip_apply.xml
+++ b/tools/retip/retip_apply.xml
@@ -1,8 +1,9 @@
-<tool id="retip_apply" name="Retip prediction" version="@TOOL_VERSION@+galaxy4">
+<tool id="retip_apply" name="Retip prediction" version="@TOOL_VERSION@+galaxy5">
     <description>is retention time predictor for Metabolomics</description>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="refs"/>
     <expand macro="creator"/>
 
     <expand macro="requirements"/>

--- a/tools/retip/retip_descriptors.xml
+++ b/tools/retip/retip_descriptors.xml
@@ -1,8 +1,9 @@
-<tool id="retip_descriptors" name="Retip chemical descriptors" version="@TOOL_VERSION@+galaxy4">
+<tool id="retip_descriptors" name="Retip chemical descriptors" version="@TOOL_VERSION@+galaxy5">
     <description>for retention time prediction</description>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="refs"/>
     <expand macro="creator"/>
 
     <expand macro="requirements"/>

--- a/tools/retip/retip_filter_rt.xml
+++ b/tools/retip/retip_filter_rt.xml
@@ -1,8 +1,9 @@
-<tool id="retip_filter_rt" name="Retip filter" version="@TOOL_VERSION@+galaxy4">
+<tool id="retip_filter_rt" name="Retip filter" version="@TOOL_VERSION@+galaxy5">
     <description>for predicted RT's</description>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="refs"/>
     <expand macro="creator"/>
 
     <expand macro="requirements"/>

--- a/tools/retip/retip_train.xml
+++ b/tools/retip/retip_train.xml
@@ -1,8 +1,9 @@
-<tool id="retip_train" name="Retip training" version="@TOOL_VERSION@+galaxy4">
+<tool id="retip_train" name="Retip training" version="@TOOL_VERSION@+galaxy5">
     <description>the Keras model to predict retention times</description>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="refs"/>
     <expand macro="creator"/>
 
     <expand macro="requirements"/>


### PR DESCRIPTION
Added xref to retip and recetox-msfinder. Galaxy should pull the EDAM operations implicitly from there.

closes #417 closes #418 