### PR TITLE
fix matchms outputs to existing types

### DIFF
--- a/tools/matchms/matchms_networking.xml
+++ b/tools/matchms/matchms_networking.xml
@@ -94,7 +94,7 @@
             <param name="scores" value="scores.json" ftype="json"/>
             <param name="graph_format" value="graphml"/>
             <param name="identifier_key" value="compound_name"/>
-            <output name="similarity_network_file" ftype="graphml">
+            <output name="similarity_network_file" ftype="xml">
                 <assert_contents>
                     <is_valid_xml />
                     <has_line_matching expression='.*node id="C[0-9]*"\/.' n="51"/>
@@ -107,7 +107,7 @@
             <param name="scores" value="scores.json" ftype="json"/>
             <param name="graph_format" value="cyjs"/>
             <param name="identifier_key" value="compound_name"/>
-            <output name="similarity_network_file" ftype="cyjs">
+            <output name="similarity_network_file" ftype="json">
                 <assert_contents>
                     <has_text_matching expression='{"data": {"id": "C[0-9]*", "value": "C[0-9]*", "name": "C[0-9]*"}}' n="51"/>
                     <has_text_matching expression='{"data": {"weight": 0\.[0-9]*, "source": "C[0-9]*", "target": "C[0-9]*"}}' n="4"/>
@@ -118,7 +118,7 @@
             <param name="scores" value="scores.json" ftype="json"/>
             <param name="graph_format" value="gexf"/>
             <param name="identifier_key" value="compound_name"/>
-            <output name="similarity_network_file" ftype="gexf">
+            <output name="similarity_network_file" ftype="xml">
             <assert_contents>
                 <is_valid_xml />
                 <has_line_matching expression='.*node id="C[0-9]*" label="C[0-9]*" \/.' n="51"/>
@@ -130,7 +130,7 @@
             <param name="scores" value="scores.json" ftype="json"/>
             <param name="graph_format" value="gml"/>
             <param name="identifier_key" value="compound_name"/>
-            <output name="similarity_network_file" ftype="gml">
+            <output name="similarity_network_file" ftype="xml">
                 <assert_contents>
                     <has_line_matching expression='\s*node \[\n\s*id [0-9]*\n\s*label "C[0-9]*"\n\s*\]' n="51"/>
                     <has_line_matching expression='\s*edge \[\n\s*source [0-9]*\n\s*target [0-9]*\n\s*weight 0\.[0-9]*\n\s*\]' n="4"/>
@@ -153,7 +153,7 @@
             <param name="graph_format" value="graphml"/>
             <param name="identifier_key" value="compound_name"/>
             <param name="keep_unconnected_nodes" value="false"/>
-            <output name="similarity_network_file" ftype="graphml">
+            <output name="similarity_network_file" ftype="xml">
                 <assert_contents>
                     <is_valid_xml />
                     <has_line_matching expression='.*node id="C[0-9]*"\/.' n="8"/>
@@ -168,7 +168,7 @@
             <param name="identifier_key" value="compound_name"/>
             <param name="score_cutoff" value="0.4"/>
             <param name="keep_unconnected_nodes" value="false"/>
-            <output name="similarity_network_file" ftype="graphml">
+            <output name="similarity_network_file" ftype="xml">
                 <assert_contents>
                     <is_valid_xml />
                     <has_line_matching expression='.*node id="C[0-9]*"\/.' n="20"/>
@@ -184,7 +184,7 @@
             <param name="score_cutoff" value="0.8"/>
             <param name="link_method" value="mutual"/>
             <param name="keep_unconnected_nodes" value="false"/>
-            <output name="similarity_network_file" ftype="cyjs">
+            <output name="similarity_network_file" ftype="json">
                 <assert_contents>
                     <has_text_matching expression='{"data": {"id": "C[0-9]*", "value": "C[0-9]*", "name": "C[0-9]*"}}' n="6"/>
                     <has_text_matching expression='{"data": {"weight": 0\.[0-9]*, "source": "C[0-9]*", "target": "C[0-9]*"}}' n="3"/>
@@ -197,7 +197,7 @@
             <param name="identifier_key" value="compound_name"/>
             <param name="score_cutoff" value="0.4"/>
             <param name="keep_unconnected_nodes" value="false"/>
-            <output name="similarity_network_file" ftype="graphml">
+            <output name="similarity_network_file" ftype="xml">
                 <assert_contents>
                     <is_valid_xml />
                 </assert_contents>

--- a/tools/matchms/matchms_networking.xml
+++ b/tools/matchms/matchms_networking.xml
@@ -1,4 +1,4 @@
-<tool id="matchms_networking" name="matchms networking" version="@TOOL_VERSION@+galaxy1" profile="21.09">
+<tool id="matchms_networking" name="matchms networking" version="@TOOL_VERSION@+galaxy2" profile="21.09">
     <description>create similarity network graph from matchms similarity scores</description>
 
     <macros>
@@ -78,12 +78,12 @@
     </inputs>
 
     <outputs>
-        <data label="Similarity network of ${scores.name}" name="similarity_network_file" format="graphml">
+        <data label="Similarity network of ${scores.name}" name="similarity_network_file" format="xml">
             <change_format>
-                <when input="graph_format" value="graphml" format="graphml"/>
-                <when input="graph_format" value="cyjs" format="cyjs"/>
-                <when input="graph_format" value="gexf" format="gexf"/>
-                <when input="graph_format" value="gml" format="gml"/>
+                <when input="graph_format" value="graphml" format="xml"/>
+                <when input="graph_format" value="cyjs" format="json"/>
+                <when input="graph_format" value="gexf" format="xml"/>
+                <when input="graph_format" value="gml" format="xml"/>
                 <when input="graph_format" value="json" format="json"/>
             </change_format>
         </data>


### PR DESCRIPTION
Otherwise, the data can not be used in downstream tools/visualizations (or the user needs to set the datatype).

