### PR TITLE
Matchms networking: error message

### DIFF
--- a/tools/matchms/matchms_networking.xml
+++ b/tools/matchms/matchms_networking.xml
@@ -17,31 +17,25 @@
     </requirements>
 
     <command detect_errors="aggressive"><![CDATA[
-        sh ${matchms_networking_cli}
+        python3 '${__tool_directory__}/matchms_networking_wrapper.py'
+            --score_name '${score_layer_name}'
+            --graph_format '$graph_format'
+            --identifier '$identifier_key'
+            --top_n '$top_n'
+            --max_links '$max_links'
+            --score_cutoff '$score_cutoff'
+            --link_method '$link_method'
+            #if $keep_unconnected_nodes
+            --keep_unconnected_nodes
+            #end if
+            '$scores'
+            '$similarity_network_file'
     ]]></command>
 
     <environment_variables>
         <environment_variable name="MPLCONFIGDIR">\$_GALAXY_JOB_TMP_DIR</environment_variable>
         <environment_variable name="XDG_CACHE_HOME">\$_GALAXY_JOB_TMP_DIR</environment_variable>
     </environment_variables>
-
-    <configfiles>
-        <configfile name="matchms_networking_cli">
-            python3 ${__tool_directory__}/matchms_networking_wrapper.py \
-            --score_name '${score_layer_name}' \
-            --graph_format '$graph_format' \
-            --identifier '$identifier_key' \
-            --top_n '$top_n' \
-            --max_links '$max_links' \
-            --score_cutoff '$score_cutoff' \
-            --link_method '$link_method' \
-            #if $keep_unconnected_nodes
-            --keep_unconnected_nodes \
-            #end if
-            '$scores' \
-            '$similarity_network_file'
-        </configfile>
-    </configfiles>
 
     <inputs>
         <param label="Similarity scores" name="scores" type="data" format="json"

--- a/tools/matchms/matchms_networking.xml
+++ b/tools/matchms/matchms_networking.xml
@@ -84,6 +84,19 @@
     </outputs>
 
     <tests>
+
+        <test expect_exit_code="1" expect_failure="true">
+            <param name="scores" value="scores.json" ftype="json"/>
+            <param name="graph_format" value="cyjs"/>
+            <param name="max_links" value="5"/>
+            <param name="score_cutoff" value="0.3"/>
+            <param name="identifier_key" value="COMPOUND_NAME"/>
+            <param name="keep_unconnected_nodes" value="false"/>
+            <assert_stderr>
+                <has_text text="ValueError: None cannot be a node"/>
+            </assert_stderr>
+        </test>
+
         <test>
             <param name="scores" value="scores.json" ftype="json"/>
             <param name="graph_format" value="graphml"/>


### PR DESCRIPTION
The new test currently gives a python Traceback that is hard to read by users. Can this be improved in the wrapper / matchms?