### PR TITLE
RAMClustR: fixed sample name reading for tabular inputs

### DIFF
--- a/tools/ramclustr/macros.xml
+++ b/tools/ramclustr/macros.xml
@@ -66,7 +66,7 @@
     </xml>
 
     <xml name="parameters_recetox_aplcms">
-        <section name="ms_dataframe" title="Input MS Data as parquet (output from recetox-aplcms)" expanded="true">
+        <section name="ms_dataframe" title="Input MS Data as parquet/tabular (output from recetox-aplcms)" expanded="true">
             <param label="Input MS1 featureDefinitions" name="ms1_featureDefinitions" type="data" format="parquet,tabular"
                    help="Metadata with columns: mz, rt, feature names containing MS data."/>
             <param label="Input MS1 featureValues" name="ms1_featureValues" type="data" format="parquet,tabular"

--- a/tools/ramclustr/ramclustr.xml
+++ b/tools/ramclustr/ramclustr.xml
@@ -1,4 +1,4 @@
-<tool id="ramclustr" name="RAMClustR" version="@TOOL_VERSION@+galaxy6" profile="21.09">
+<tool id="ramclustr" name="RAMClustR" version="@TOOL_VERSION@+galaxy7" profile="21.09">
     <description>A feature clustering algorithm for non-targeted mass spectrometric metabolomics data.</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/ramclustr/ramclustr_wrapper.R
+++ b/tools/ramclustr/ramclustr_wrapper.R
@@ -53,14 +53,17 @@ read_ramclustr_aplcms <- function(ms1_featuredefinitions = NULL,
     ms1_featuredefinitions <- arrow::read_parquet(ms1_featuredefinitions)
   } else {
     ms1_featuredefinitions <- read.csv(ms1_featuredefinitions,
-      header = TRUE, sep = "\t"
+      header = TRUE, sep = "\t", check.names = FALSE
     )
   }
 
   if (ms1_featurevalues_ext == "parquet") {
     ms1_featurevalues <- arrow::read_parquet(ms1_featurevalues)
   } else {
-    ms1_featurevalues <- read.csv(ms1_featurevalues, header = TRUE, sep = "\t")
+    ms1_featurevalues <- read.csv(ms1_featurevalues,
+      header = TRUE,
+      sep = "\t", check.names = FALSE
+    )
   }
 
   if (!is.null(df_phenodata)) {


### PR DESCRIPTION
fixed sample name reading by disabling `check.names` for tabular inputs

closes #540 