### PR TITLE
EDAM annotations for QCxMS and xTB tools

### DIFF
--- a/tools/qcxms/macros.xml
+++ b/tools/qcxms/macros.xml
@@ -10,7 +10,7 @@
             <edam_topic>topic_3332</edam_topic>
         </edam_topics>
         <edam_operations>
-            <edam_operation>operation_0297</edam_operation>
+            <edam_operation>operation_3860</edam_operation>
         </edam_operations>
     </xml>
 

--- a/tools/qcxms/qcxms_getres.xml
+++ b/tools/qcxms/qcxms_getres.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_getres" name="QCxMS get results" version="@TOOL_VERSION@+galaxy1" profile="22.09">
+<tool id="qcxms_getres" name="QCxMS get results" version="@TOOL_VERSION@+galaxy2" profile="22.09">
     <description>Get result of the Production run to obtain a QCxMS simulated mass spectrum</description>
     
     <macros>

--- a/tools/qcxms/qcxms_neutral_run.xml
+++ b/tools/qcxms/qcxms_neutral_run.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_neutral_run" name="QCxMS neutral run" version="@TOOL_VERSION@+galaxy3" profile="22.09">
+<tool id="qcxms_neutral_run" name="QCxMS neutral run" version="@TOOL_VERSION@+galaxy4" profile="22.09">
     <description>required as first step to prepare for the production runs</description>
     
     <macros>

--- a/tools/qcxms/qcxms_prod_run.xml
+++ b/tools/qcxms/qcxms_prod_run.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_production_run" name="QCxMS production run" version="@TOOL_VERSION@+galaxy2" profile="22.09">
+<tool id="qcxms_production_run" name="QCxMS production run" version="@TOOL_VERSION@+galaxy3" profile="22.09">
     <description>Production run to obtain a QCxMS simulated mass spectrum</description>
     
     <macros>

--- a/tools/xtb/macros.xml
+++ b/tools/xtb/macros.xml
@@ -1,5 +1,13 @@
 <macros>
     <token name="@TOOL_VERSION@">6.6.1</token>
+    <xml name="edam">
+        <edam_topics>
+            <edam_topic>topic_3332</edam_topic>
+        </edam_topics>
+        <edam_operations>
+            <edam_operation>operation_0297</edam_operation>
+        </edam_operations>
+    </xml>
     <xml name="creator">
     <creator>
         <person

--- a/tools/xtb/xtb_molecular_optimization.xml
+++ b/tools/xtb/xtb_molecular_optimization.xml
@@ -1,8 +1,9 @@
-<tool id="xtb_molecular_optimization" name="xtb molecular optimization" version="@TOOL_VERSION@+galaxy2" profile="21.09">
+<tool id="xtb_molecular_optimization" name="xtb molecular optimization" version="@TOOL_VERSION@+galaxy3" profile="21.09">
     <description>Semiempirical quantum mechanical molecular optimization method</description>
     <macros>
         <import>macros.xml</import>
     </macros>
+    <expand macro="edam"/>
     <expand macro="creator"/>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">xtb</requirement>


### PR DESCRIPTION
Updated operation number for qcxms tools to "opeation_3860" (Analysis -> Spectral analysis -> Spectrum calculation)
For xtb tool, added topic_332 and operation_0297.

closes https://github.com/RECETOX/galaxytools/issues/559