### PR TITLE
Add tstep and etemp parameters to the QCxMS tool

### DIFF
--- a/tools/qcxms/qcxms_neutral_run.xml
+++ b/tools/qcxms/qcxms_neutral_run.xml
@@ -120,7 +120,7 @@ rename_files_with_folder_name(path)
             </output>
             <output name="log">
                 <assert_contents>
-                    <has_size value="10518" delta="300"/>
+                    <has_size value="10518" delta="500"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/qcxms/qcxms_neutral_run.xml
+++ b/tools/qcxms/qcxms_neutral_run.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_neutral_run" name="QCxMS neutral run" version="@TOOL_VERSION@+galaxy4" profile="22.09">
+<tool id="qcxms_neutral_run" name="QCxMS neutral run" version="@TOOL_VERSION@+galaxy5" profile="22.09">
     <description>required as first step to prepare for the production runs</description>
     
     <macros>
@@ -30,7 +30,9 @@ ntraj  ${keywords.ntraj}
 #end if
 tmax  ${keywords.tmax} 
 tinit  ${keywords.tinit} 
-ieeatm  ${keywords.ieeatm}]]>
+ieeatm  ${keywords.ieeatm}
+tstep  ${keywords.tstep}
+etemp  ${keywords.etemp}]]>
         </configfile>
         <configfile filename="rename.py">
 import os
@@ -64,11 +66,12 @@ rename_files_with_folder_name(path)
         <section name="keywords" title="Advanced method parameters" expanded="false" 
             help="List of advanced keywords to specify the method - for more information see [1].">
             <param name="tmax" type="float" value="20.0" label="Maximum MD time (sampling) [ps]"
-            help="MD time for the mean-free-path (mfp) simulation in the EI mode. In the CID mode, this sets the number of time steps for the simulation 
-            after fragmentation during internal energy scaling (implicit run type). For the explicit run type, the time for the collision MDs is fixed at 50 fs * number_of_atoms."/>
+            help="MD time for the mean-free-path (mfp) simulation in the EI mode."/>
             <param name="tinit" type="float" value="500.0" label="Initial Temperature [K]"/>
             <param name="ieeatm" type="float" value="0.6" label="Impact excess energy (IEE) per atom [eV/atom]" />
             <param name="ntraj" type="integer" optional="true" min="2" label="Number of trajectories[#]" help="Default is 25 * no. of atoms if unspecified."/>
+            <param name="tstep" type="float" value="0.5" label="MD time step (tstep) [fs]" help="Default is 0.5 fs."/>
+            <param name="etemp" type="float" value="5000" label="Electronic temperature (etemp) [K]" help="Default is 5000 K."/>
         </section>
         <param name="store_extended_output" type="boolean" value="false" label="Store additional outputs?" help="Output the logfile and generated trajectory."/>
     </inputs>

--- a/tools/qcxms/test-data/TMP.1_qcxms_in.txt
+++ b/tools/qcxms/test-data/TMP.1_qcxms_in.txt
@@ -4,4 +4,6 @@
             tmax  20.0 
             tinit  500.0 
             ieeatm  0.6
+            tstep 0.5
+            etemp 5000
         


### PR DESCRIPTION
This PR introduces the advanced parameters `tstep` and `etemp` to the QCxMS neutral run. It also removes the sentence about CID, which is not implemented in this version, from the `tmax` parameter's help description. 

closes https://github.com/RECETOX/galaxytools/issues/585