### PR TITLE
signal-to-noise separated into ratio and noise in IsoFiltR

### DIFF
--- a/tools/mfassignr/macros.xml
+++ b/tools/mfassignr/macros.xml
@@ -140,8 +140,7 @@
     <xml name="isofiltr_param">
         <param name="peaks" type="data" format="tabular" label="Input Peak Data"
         help="The input data frame containing abundance and peak mass."/>
-        <param name="SN" type="float" value="0" label="Signal-to-Noise Ratio"
-        help="Sets the noise cut for the data; peaks below this value will not be evaluated."/>
+        <expand macro="noise_threshold_params" />
         <param name="Carbrat" type="float" value="60" min="5" label="Maximum 13C/12C Ratio"
         help="Sets the maximum allowed ratio for matching 13C isotopes."/>
         <param name="Sulfrat" type="float" value="30" label="Maximum 34S/32S Ratio"

--- a/tools/mfassignr/macros.xml
+++ b/tools/mfassignr/macros.xml
@@ -68,8 +68,7 @@
     <xml name="snplot_param">
         <param name="input_file" type="data" format="tabular" label="Input data"
                help= "Input data frame, first column is mass, second column is intensity"/>
-        <param name="cut" type="float" label="cut" value="0"
-               help= "A numeric value of the intensity cut value being investigated"/>
+        <expand macro="noise_threshold_params" />
         <param name="mass" type="float" label="mass" value="300"
                help= "A numeric value setting a centerpoint to look at the mass spectrum"/>
         <param name="window_x" type="float" label="window.x" value="0.5"

--- a/tools/mfassignr/mfassignr_isofiltr.xml
+++ b/tools/mfassignr/mfassignr_isofiltr.xml
@@ -1,4 +1,4 @@
-<tool id="mfassignr_isofiltr" name="MFAssignR IsoFiltR" version="@TOOL_VERSION@+galaxy0" profile="23.0">
+<tool id="mfassignr_isofiltr" name="MFAssignR IsoFiltR" version="@TOOL_VERSION@+galaxy1" profile="23.0">
     <description>Separates likely isotopic masses from monoisotopic masses in a mass list</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/mfassignr/mfassignr_isofiltr.xml
+++ b/tools/mfassignr/mfassignr_isofiltr.xml
@@ -21,9 +21,11 @@
     <configfiles>
         <configfile name="mfassignr_isofiltr"><![CDATA[
             peaks <- read.table("$peaks", header=TRUE, sep="\t")
+            SN = $sn_ratio * $kmdn
+
             result <- MFAssignR::IsoFiltR(
                 peaks = peaks,
-                SN = $SN,
+                SN = SN,
                 Carbrat = $Carbrat,
                 Sulfrat = $Sulfrat,
                 Sulferr = $Sulferr,

--- a/tools/mfassignr/mfassignr_snplot.xml
+++ b/tools/mfassignr/mfassignr_snplot.xml
@@ -1,4 +1,4 @@
-<tool id="mfassignr_snplot" name="MFAssignR SNplot" version="@TOOL_VERSION@+galaxy0" profile="23.0">
+<tool id="mfassignr_snplot" name="MFAssignR SNplot" version="@TOOL_VERSION@+galaxy1" profile="23.0">
     <description>Noise level assessment using the SNplot function.</description>
     <macros>
         <import>macros.xml</import>
@@ -14,9 +14,11 @@
     ]]></command>
     <configfiles>
         <configfile name="run_script"><![CDATA[
+        cut = $sn_ratio * $kmdn
+                    
         SNplot <- MFAssignR::SNplot(
             df = read.delim("$input_file", sep="\t"),
-            cut = $cut,
+            cut = cut,
             mass = $mass,
             window.x = $window_x,
             window.y = $window_y
@@ -34,7 +36,7 @@
     <tests>
         <test>
             <param name="input_file" value="QC1_1_POS_500.tabular"/>
-            <param name="cut" value="3294705.63963789"/>
+            <param name="kmdn" value="3294705.63963789"/>
             <param name="mass" value="300"/>
             <output name="SNplot" ftype="png" file="snplot/plot.png" />
         </test>

--- a/tools/mfassignr/mfassignr_snplot.xml
+++ b/tools/mfassignr/mfassignr_snplot.xml
@@ -36,7 +36,7 @@
     <tests>
         <test>
             <param name="input_file" value="QC1_1_POS_500.tabular"/>
-            <param name="kmdn" value="3294705.63963789"/>
+            <param name="kmdn" value="549117.606606315"/>
             <param name="mass" value="300"/>
             <output name="SNplot" ftype="png" file="snplot/plot.png" />
         </test>


### PR DESCRIPTION
Signal-to-ratio parameter is now separated into `kmdn` * `SN_ratio` similarly as it's done in other functions (e.g. MFAssign). 

closes #588 