### PR TITLE
Fixed issue in QCxMS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     types: [run-all-tool-tests-command]
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_24.1
+  GALAXY_BRANCH: release_24.2
   MAX_CHUNKS: 40
 jobs:
   setup:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -134,6 +134,7 @@ jobs:
         fail-level: warn
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
+        additional-planemo-options: --skip version_bumped
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:

--- a/tools/qcxms/qcxms_getres.xml
+++ b/tools/qcxms/qcxms_getres.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_getres" name="QCxMS get results" version="@TOOL_VERSION@+galaxy2" profile="22.09">
+<tool id="qcxms_getres" name="QCxMS get results" version="@TOOL_VERSION@+galaxy3" profile="22.09">
     <description>Get result of the Production run to obtain a QCxMS simulated mass spectrum</description>
     
     <macros>
@@ -38,7 +38,7 @@ with open(output_file, 'w') as output:
 
     <inputs>
         <param type="data" name="mol" label="Molecule 3D structure [.xyz]" format="xyz" />
-        <param type="data_collection" collection_type="list" name="res_files" label="res files [.res]" format="txt,text"/>
+        <param type="data_collection" collection_type="list" name="res_files" label="res files [.res]" format="txt"/>
     </inputs>
 
     <outputs>

--- a/tools/qcxms/qcxms_neutral_run.xml
+++ b/tools/qcxms/qcxms_neutral_run.xml
@@ -121,7 +121,7 @@ rename_files_with_folder_name(path)
             </output>
             <output name="log">
                 <assert_contents>
-                    <has_size value="10518" delta="500"/>
+                    <has_size value="11103" delta="500"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/qcxms/qcxms_neutral_run.xml
+++ b/tools/qcxms/qcxms_neutral_run.xml
@@ -66,7 +66,7 @@ rename_files_with_folder_name(path)
         </param>
         <section name="keywords" title="Advanced method parameters" expanded="false" 
             help="List of advanced keywords to specify the method - for more information see [1].">
-            <param name="tmax" type="integer" value="20" label="Maximum MD time (sampling) [ps]"
+            <param name="tmax" type="integer" value="5" label="Maximum MD time (sampling) [ps]"
             help="MD time for the mean-free-path (mfp) simulation in the EI mode."/>
             <param name="tinit" type="integer" value="500" label="Initial Temperature [K]"/>
             <param name="ieeatm" type="float" value="0.6" label="Impact excess energy (IEE) per atom [eV/atom]" />

--- a/tools/qcxms/qcxms_neutral_run.xml
+++ b/tools/qcxms/qcxms_neutral_run.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_neutral_run" name="QCxMS neutral run" version="@TOOL_VERSION@+galaxy5" profile="22.09">
+<tool id="qcxms_neutral_run" name="QCxMS neutral run" version="@TOOL_VERSION@+galaxy6" profile="22.09">
     <description>required as first step to prepare for the production runs</description>
     
     <macros>
@@ -29,10 +29,11 @@ ${QC_Level}
 ntraj  ${keywords.ntraj}
 #end if
 tmax  ${keywords.tmax} 
+etemp  ${keywords.etemp}
 tinit  ${keywords.tinit} 
 ieeatm  ${keywords.ieeatm}
 tstep  ${keywords.tstep}
-etemp  ${keywords.etemp}]]>
+]]>
         </configfile>
         <configfile filename="rename.py">
 import os
@@ -65,13 +66,13 @@ rename_files_with_folder_name(path)
         </param>
         <section name="keywords" title="Advanced method parameters" expanded="false" 
             help="List of advanced keywords to specify the method - for more information see [1].">
-            <param name="tmax" type="float" value="20.0" label="Maximum MD time (sampling) [ps]"
+            <param name="tmax" type="integer" value="20" label="Maximum MD time (sampling) [ps]"
             help="MD time for the mean-free-path (mfp) simulation in the EI mode."/>
-            <param name="tinit" type="float" value="500.0" label="Initial Temperature [K]"/>
+            <param name="tinit" type="integer" value="500" label="Initial Temperature [K]"/>
             <param name="ieeatm" type="float" value="0.6" label="Impact excess energy (IEE) per atom [eV/atom]" />
             <param name="ntraj" type="integer" optional="true" min="2" label="Number of trajectories[#]" help="Default is 25 * no. of atoms if unspecified."/>
             <param name="tstep" type="float" value="0.5" label="MD time step (tstep) [fs]" help="Default is 0.5 fs."/>
-            <param name="etemp" type="float" value="5000" label="Electronic temperature (etemp) [K]" help="Default is 5000 K."/>
+            <param name="etemp" type="integer" value="5000" label="Electronic temperature (etemp) [K]" help="Default is 5000 K."/>
         </section>
         <param name="store_extended_output" type="boolean" value="false" label="Store additional outputs?" help="Output the logfile and generated trajectory."/>
     </inputs>

--- a/tools/qcxms/qcxms_prod_run.xml
+++ b/tools/qcxms/qcxms_prod_run.xml
@@ -1,4 +1,4 @@
-<tool id="qcxms_production_run" name="QCxMS production run" version="@TOOL_VERSION@+galaxy3" profile="22.09">
+<tool id="qcxms_production_run" name="QCxMS production run" version="@TOOL_VERSION@+galaxy4" profile="22.09">
     <description>Production run to obtain a QCxMS simulated mass spectrum</description>
     
     <macros>
@@ -41,9 +41,9 @@ shutil.copy2(os.path.join(os.path.dirname('$xyz_file'), '$xyz_file'), os.path.jo
     </configfiles>
 
     <inputs>
-        <param type="data" name="in_file" label="in files [.in]" format="txt,text"/>
-        <param type="data" name="start_file" label="start files [.start]" format="txt,text"/>
-        <param type="data" name="xyz_file" label="xyz files [.xyz]" format="xyz,txt,text"/>
+        <param type="data" name="in_file" label="in files [.in]" format="txt"/>
+        <param type="data" name="start_file" label="start files [.start]" format="txt"/>
+        <param type="data" name="xyz_file" label="xyz files [.xyz]" format="xyz,txt"/>
         <param name="store_extended_output" type="boolean" value="false" label="Store additional outputs" help="Output the logfile."/>
     </inputs>
 


### PR DESCRIPTION
Moved etemp parameter higher up so it for some reason doesn't overwrite the tinit parameter.

Fixes #646