### PR TITLE
wavica: accept tabular as input

### DIFF
--- a/tools/waveica/macros.xml
+++ b/tools/waveica/macros.xml
@@ -29,22 +29,7 @@
     <xml name="input_data">
         <param type="data" name="data" label="Feature table" format="csv,tsv,tabular,parquet" help=""/>
     </xml>
-    <xml name="general_parameters">
-        <param type="integer" value="20" name="k" label="Number of components to decompose" help="maximal component that ICA decomposes"/>
-        <param type="float" value="0" name="alpha" label="Alpha" help="trade-off value between the independence of samples (temporal ICA) and variables (spatial ICA), should be between 0 and 1"/>
-    </xml>
-    <xml name="batchwise_parameters">
-        <param type="float" value="0.05" name="t" label="Batch-association threshold" help="threshold to consider a component associate with the batch,
-        should be between 0 and 1"/>
-        <param type="float" value="0.05" name="t2" label="Group-association threshold" help="threshold to consider a component associate with the group,
-        should be between 0 and 1"/>
-    </xml>
-    <xml name="singlebatch_parameters">
-        <param type="float" value="0" name="cutoff" label="Cutoff" help="threshold of the variation explained by the injection order for independent components, should be between 0 and 1"/>
-    </xml>
-    <xml name="exclude_blanks">
-        <param name="exclude_blanks" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Remove blanks" help="Excludes blank samples from the output" />
-    </xml>
+
     <xml name="wf">
         <conditional name="wf">
             <param type="select" name="wavelet_filter" label="Wavelet transform filter" help="wavelet function and filter length [1] (see footnotes for more details)">

--- a/tools/waveica/macros.xml
+++ b/tools/waveica/macros.xml
@@ -22,12 +22,12 @@
 
     <xml name="annotation">
         <xrefs>
-               <xref type="bio.tools">waveica</xref>
+            <xref type="bio.tools">waveica</xref>
         </xrefs>
      </xml>
 
     <xml name="input_data">
-        <param type="data" name="data" label="Feature table" format="csv,tsv,parquet" help=""/>
+        <param type="data" name="data" label="Feature table" format="csv,tsv,tabular,parquet" help=""/>
     </xml>
     <xml name="general_parameters">
         <param type="integer" value="20" name="k" label="Number of components to decompose" help="maximal component that ICA decomposes"/>

--- a/tools/waveica/waveica.xml
+++ b/tools/waveica/waveica.xml
@@ -97,39 +97,45 @@
             <conditional name="input_num">
                 <param name="data" value="input_data.csv" ftype="csv"/>
             </conditional>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 2 -->
             <conditional name="input_num">
                 <param name="data" value="input_data.tsv" ftype="tsv"/>
             </conditional>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 3 -->
             <conditional name="input_num">
                 <param name="data" value="input_data.parquet" ftype="parquet"/>
             </conditional>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.parquet" ftype="parquet"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 4 -->
@@ -138,13 +144,15 @@
                 <param name="data" value="feature_table.csv" ftype="csv"/>
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
             </conditional>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 5 -->
@@ -153,13 +161,15 @@
                 <param name="data" value="feature_table.tsv" ftype="tabular"/>
                 <param name="metadata" value="metadata.tsv" ftype="tabular"/>
             </conditional>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 6 -->
@@ -182,15 +192,17 @@
                 <param name="input_choice" value="2"/>
                 <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
                 <param name="metadata" value="metadata.parquet" ftype="parquet"/>
+                <param name="transpose_feature_table" value="TRUE"/>
             </conditional>
-            <param name="transpose_feature_table" value="TRUE"/>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.parquet" compare="sim_size" delta="200" ftype="parquet"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 8 -->
@@ -198,15 +210,17 @@
                 <param name="input_choice" value="2"/>
                 <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
+                <param name="transpose_feature_table" value="TRUE"/>
             </conditional>
-            <param name="transpose_feature_table" value="TRUE"/>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="2"><!-- TEST 9 -->
@@ -214,15 +228,17 @@
                 <param name="input_choice" value="2"/>
                 <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
                 <param name="metadata" value="metadata.parquet" ftype="parquet"/>
+                <param name="transpose_feature_table" value="TRUE"/>
             </conditional>
-            <param name="transpose_feature_table" value="TRUE"/>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <param name="keep_two_output" value="TRUE"/>
             <output name="normalized_data" file="test9_output1.parquet" ftype="parquet"/>
             <output name="metadata" file="test9_output2.parquet" ftype="parquet"/>
@@ -232,15 +248,17 @@
                 <param name="input_choice" value="2"/>
                 <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
+                <param name="transpose_feature_table" value="TRUE"/>
             </conditional>
-            <param name="transpose_feature_table" value="TRUE"/>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
+                <param name="wavelet_filter" value="d"/>
+                <param name="wavelet_length" value="2"/>
+                <param name="k" value="20"/>
+                <param name="t" value="0.05"/>
+                <param name="t2" value="0.05"/>
+                <param name="alpha" value="0"/>
+            </conditional>
             <param name="keep_two_output" value="TRUE"/>
             <output name="normalized_data" file="test10_output1.tsv" ftype="tabular"/>
             <output name="metadata" file="test10_output2.tsv" ftype="tabular"/>

--- a/tools/waveica/waveica.xml
+++ b/tools/waveica/waveica.xml
@@ -18,8 +18,8 @@
             -e 'normalized_data <- waveica(
                 file = "$input_num.data",
                 #if $input_num.input_choice == "2":
-                    metadata = "$input_num.input_metadata.metadata",
-                    ext = "$input_num.data.ext,$input_num.input_metadata.metadata.ext",
+                    metadata = "$input_num.metadata",
+                    ext = "$input_num.data.ext,$input_num.metadata.ext",
                     transpose = $input_num.transpose_feature_table,
                 #else:
                     ext = "$input_num.data.ext",
@@ -36,8 +36,8 @@
             -e 'normalized_data <- waveica_singlebatch( 
                 file = "$input_num.data",
                 #if $input_num.input_choice == "2":
-                    metadata = "$input_num.input_metadata.metadata",
-                    ext = "$input_num.data.ext,$input_num.input_metadata.metadata.ext",
+                    metadata = "$input_num.metadata",
+                    ext = "$input_num.data.ext,$input_num.metadata.ext",
                     transpose = $input_num.transpose_feature_table,
                 #else:
                     ext = "$input_num.data.ext",
@@ -65,9 +65,7 @@
             </when>
             <when value="2">
                 <expand macro="input_data"/>
-                <section name="input_metadata" title="Input metadata table" expanded="true">
-                    <param name="metadata" label="Input metadata" type="data" format="csv,tsv,tabular,parquet" help="" />
-                </section>
+                <param name="metadata" label="Input metadata" type="data" format="csv,tsv,tabular,parquet" help="" />
                 <param name = "transpose_feature_table" label="Transpose feature table" type="boolean" checked="false" 
                 truevalue="TRUE" falsevalue="FALSE" help="Swap sample names with feature names as column headers (to fit recetox-aplcms outputs)." />
             </when>
@@ -96,7 +94,9 @@
 
     <tests>
         <test expect_num_outputs="1"><!-- TEST 1 -->
-            <param name="data" value="input_data.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="data" value="input_data.csv" ftype="csv"/>
+            </conditional>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
             <param name="wavelet_length" value="2"/>
@@ -107,7 +107,9 @@
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 2 -->
-            <param name="data" value="input_data.tsv" ftype="tsv"/>
+            <conditional name="input_num">
+                <param name="data" value="input_data.tsv" ftype="tsv"/>
+            </conditional>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
             <param name="wavelet_length" value="2"/>
@@ -118,7 +120,9 @@
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 3 -->
-            <param name="data" value="input_data.parquet" ftype="parquet"/>
+            <conditional name="input_num">
+                <param name="data" value="input_data.parquet" ftype="parquet"/>
+            </conditional>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
             <param name="wavelet_length" value="2"/>

--- a/tools/waveica/waveica.xml
+++ b/tools/waveica/waveica.xml
@@ -1,4 +1,4 @@
-<tool id="waveica" name="WaveICA" version="@TOOL_VERSION@+galaxy8" profile="21.09">
+<tool id="waveica" name="WaveICA" version="@TOOL_VERSION@+galaxy9" profile="23.0">
     <description>removal of batch effects for untargeted metabolomics data</description>
     <macros>
         <import>macros.xml</import>
@@ -66,7 +66,7 @@
             <when value="2">
                 <expand macro="input_data"/>
                 <section name="input_metadata" title="Input metadata table" expanded="true">
-                    <param name="metadata" label="Input metadata" type="data" format="csv,tsv,parquet" help="" />
+                    <param name="metadata" label="Input metadata" type="data" format="csv,tsv,tabular,parquet" help="" />
                 </section>
                 <param name = "transpose_feature_table" label="Transpose feature table" type="boolean" checked="false" 
                 truevalue="TRUE" falsevalue="FALSE" help="Swap sample names with feature names as column headers (to fit recetox-aplcms outputs)." />
@@ -129,9 +129,11 @@
             <output name="normalized_data" file="normalized_data.parquet" ftype="parquet"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 4 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table.csv" ftype="csv"/>
-            <param name="metadata" value="metadata.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table.csv" ftype="csv"/>
+                <param name="metadata" value="metadata.csv" ftype="csv"/>
+            </conditional>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
             <param name="wavelet_length" value="2"/>
@@ -142,9 +144,11 @@
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 5 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table.tsv" ftype="tsv"/>
-            <param name="metadata" value="metadata.tsv" ftype="tsv"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table.tsv" ftype="tabular"/>
+                <param name="metadata" value="metadata.tsv" ftype="tabular"/>
+            </conditional>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
             <param name="wavelet_length" value="2"/>
@@ -155,9 +159,11 @@
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 6 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table.parquet" ftype="parquet"/>
-            <param name="metadata" value="metadata.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table.parquet" ftype="parquet"/>
+                <param name="metadata" value="metadata.csv" ftype="csv"/>
+            </conditional>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
             <param name="wavelet_length" value="2"/>
@@ -168,9 +174,11 @@
             <output name="normalized_data" file="normalized_data.parquet" compare="sim_size" delta="200" ftype="parquet"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 7 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
-            <param name="metadata" value="metadata.parquet" ftype="parquet"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
+                <param name="metadata" value="metadata.parquet" ftype="parquet"/>
+            </conditional>
             <param name="transpose_feature_table" value="TRUE"/>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
@@ -182,9 +190,11 @@
             <output name="normalized_data" file="normalized_data.parquet" compare="sim_size" delta="200" ftype="parquet"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 8 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
-            <param name="metadata" value="metadata.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
+                <param name="metadata" value="metadata.csv" ftype="csv"/>
+            </conditional>
             <param name="transpose_feature_table" value="TRUE"/>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
@@ -195,21 +205,12 @@
             <param name="alpha" value="0"/>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
-        <!-- The following test has different results on three platform I've tried -->
-        <!-- <test>
-            <param name="data" value="input_data_nobatch.csv" ftype="csv"/>
-            <param name="mode" value="single_batch"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="filter_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="alpha" value="0"/>
-            <param name="cutoff" value="0"/>
-            <output name="normalized_data" file="normalized_data_nobatch.tsv"/>
-        </test> -->
         <test expect_num_outputs="2"><!-- TEST 9 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
-            <param name="metadata" value="metadata.parquet" ftype="parquet"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
+                <param name="metadata" value="metadata.parquet" ftype="parquet"/>
+            </conditional>
             <param name="transpose_feature_table" value="TRUE"/>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>
@@ -223,9 +224,11 @@
             <output name="metadata" file="test9_output2.parquet" ftype="parquet"/>
         </test>
         <test expect_num_outputs="2"><!-- TEST 10 -->
-            <param name="input_choice" value="2"/>
-            <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
-            <param name="metadata" value="metadata.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="input_choice" value="2"/>
+                <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
+                <param name="metadata" value="metadata.csv" ftype="csv"/>
+            </conditional>
             <param name="transpose_feature_table" value="TRUE"/>
             <param name="mode" value="batchwise"/>
             <param name="wavelet_filter" value="d"/>

--- a/tools/waveica/waveica.xml
+++ b/tools/waveica/waveica.xml
@@ -222,10 +222,14 @@
             <output name="metadata" file="test10_output2.tsv" ftype="tabular"/>
         </test>
         <test expect_failure="true"><!-- TEST 11 -->
-            <param name="data" value="na_data.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="data" value="na_data.csv" ftype="csv"/>
+            </conditional>
         </test>
         <test expect_failure="true"><!-- TEST 12 -->
-            <param name="data" value="incomplete_metadata_data.csv" ftype="csv"/>
+            <conditional name="input_num">
+                <param name="data" value="incomplete_metadata_data.csv" ftype="csv"/>
+            </conditional>
         </test>
     </tests>
 

--- a/tools/waveica/waveica.xml
+++ b/tools/waveica/waveica.xml
@@ -70,7 +70,8 @@
                 truevalue="TRUE" falsevalue="FALSE" help="Swap sample names with feature names as column headers (to fit recetox-aplcms outputs)." />
             </when>
         </conditional>
-        <expand macro="general_parameters"/>
+        <param type="integer" value="20" name="k" label="Number of components to decompose" help="maximal component that ICA decomposes"/>
+        <param type="float" value="0" name="alpha" label="Alpha" help="trade-off value between the independence of samples (temporal ICA) and variables (spatial ICA), should be between 0 and 1"/>
         <expand macro="wf"/>
         <conditional name="batch_correction">
             <param name="mode" type="select" label="Batch correction mode" help="'multiple batches' takes into account
@@ -80,13 +81,14 @@
                 <option value="single_batch">Single batch (or no batch information)</option>
             </param>
             <when value="batchwise">
-                <expand macro="batchwise_parameters"/>
+                <param type="float" value="0.05" name="t" label="Batch-association threshold" help="threshold to consider a component associate with the batch, should be between 0 and 1"/>
+                <param type="float" value="0.05" name="t2" label="Group-association threshold" help="threshold to consider a component associate with the group, should be between 0 and 1"/>
             </when>
             <when value="single_batch">
-                <expand macro="singlebatch_parameters"/>
+                <param type="float" value="0" name="cutoff" label="Cutoff" help="threshold of the variation explained by the injection order for independent components, should be between 0 and 1"/>
             </when>
         </conditional>
-        <expand macro="exclude_blanks"/>
+        <param name="exclude_blanks" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Remove blanks" help="Excludes blank samples from the output" />
         <expand macro="split_output"/>
     </inputs>
 
@@ -97,14 +99,16 @@
             <conditional name="input_num">
                 <param name="data" value="input_data.csv" ftype="csv"/>
             </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
+            <param name="alpha" value="0"/>
+            <param name="k" value="20"/>
+            <conditional name="wf">
                 <param name="wavelet_filter" value="d"/>
                 <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
+            </conditional>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
                 <param name="t" value="0.05"/>
                 <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
@@ -112,14 +116,16 @@
             <conditional name="input_num">
                 <param name="data" value="input_data.tsv" ftype="tsv"/>
             </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
+            <param name="alpha" value="0"/>
+            <param name="k" value="20"/>
+            <conditional name="wf">
                 <param name="wavelet_filter" value="d"/>
                 <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
+            </conditional>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
                 <param name="t" value="0.05"/>
                 <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
@@ -127,14 +133,16 @@
             <conditional name="input_num">
                 <param name="data" value="input_data.parquet" ftype="parquet"/>
             </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
+            <param name="k" value="20"/>
+            <param name="alpha" value="0"/>
+            <conditional name="wf">
                 <param name="wavelet_filter" value="d"/>
                 <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
+            </conditional>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
                 <param name="t" value="0.05"/>
                 <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <output name="normalized_data" file="normalized_data.parquet" ftype="parquet"/>
         </test>
@@ -144,14 +152,16 @@
                 <param name="data" value="feature_table.csv" ftype="csv"/>
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
             </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
+            <param name="alpha" value="0"/>
+            <param name="k" value="20"/>
+            <conditional name="wf">
                 <param name="wavelet_filter" value="d"/>
                 <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
+            </conditional>
+            <conditional name="batch_correction">
+                <param name="mode" value="batchwise"/>
                 <param name="t" value="0.05"/>
                 <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
@@ -161,15 +171,6 @@
                 <param name="data" value="feature_table.tsv" ftype="tabular"/>
                 <param name="metadata" value="metadata.tsv" ftype="tabular"/>
             </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
-                <param name="wavelet_filter" value="d"/>
-                <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
-                <param name="t" value="0.05"/>
-                <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
-            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 6 -->
@@ -178,13 +179,6 @@
                 <param name="data" value="feature_table.parquet" ftype="parquet"/>
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
             </conditional>
-            <param name="mode" value="batchwise"/>
-            <param name="wavelet_filter" value="d"/>
-            <param name="wavelet_length" value="2"/>
-            <param name="k" value="20"/>
-            <param name="t" value="0.05"/>
-            <param name="t2" value="0.05"/>
-            <param name="alpha" value="0"/>
             <output name="normalized_data" file="normalized_data.parquet" compare="sim_size" delta="200" ftype="parquet"/>
         </test>
         <test expect_num_outputs="1"><!-- TEST 7 -->
@@ -193,15 +187,6 @@
                 <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
                 <param name="metadata" value="metadata.parquet" ftype="parquet"/>
                 <param name="transpose_feature_table" value="TRUE"/>
-            </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
-                <param name="wavelet_filter" value="d"/>
-                <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
-                <param name="t" value="0.05"/>
-                <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <output name="normalized_data" file="normalized_data.parquet" compare="sim_size" delta="200" ftype="parquet"/>
         </test>
@@ -212,15 +197,6 @@
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
                 <param name="transpose_feature_table" value="TRUE"/>
             </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
-                <param name="wavelet_filter" value="d"/>
-                <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
-                <param name="t" value="0.05"/>
-                <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
-            </conditional>
             <output name="normalized_data" file="normalized_data.tsv" ftype="tabular"/>
         </test>
         <test expect_num_outputs="2"><!-- TEST 9 -->
@@ -229,15 +205,6 @@
                 <param name="data" value="feature_table_transpose_version.parquet" ftype="parquet"/>
                 <param name="metadata" value="metadata.parquet" ftype="parquet"/>
                 <param name="transpose_feature_table" value="TRUE"/>
-            </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
-                <param name="wavelet_filter" value="d"/>
-                <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
-                <param name="t" value="0.05"/>
-                <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <param name="keep_two_output" value="TRUE"/>
             <output name="normalized_data" file="test9_output1.parquet" ftype="parquet"/>
@@ -249,15 +216,6 @@
                 <param name="data" value="feature_table_transpose_version.csv" ftype="csv"/>
                 <param name="metadata" value="metadata.csv" ftype="csv"/>
                 <param name="transpose_feature_table" value="TRUE"/>
-            </conditional>
-            <conditional name="batch_correction">
-                <param name="mode" value="batchwise"/>
-                <param name="wavelet_filter" value="d"/>
-                <param name="wavelet_length" value="2"/>
-                <param name="k" value="20"/>
-                <param name="t" value="0.05"/>
-                <param name="t2" value="0.05"/>
-                <param name="alpha" value="0"/>
             </conditional>
             <param name="keep_two_output" value="TRUE"/>
             <output name="normalized_data" file="test10_output1.tsv" ftype="tabular"/>

--- a/tools/waveica/waveica_wrapper.R
+++ b/tools/waveica/waveica_wrapper.R
@@ -17,7 +17,7 @@ read_file <- function(file, metadata, ft_ext, mt_ext, transpose) {
 read_data <- function(file, ext) {
     if (ext == "csv") {
         data <- read.csv(file, header = TRUE)
-    } else if (ext == "tsv") {
+    } else if (ext == "tsv" || ext == "tabular") {
         data <- read.csv(file, header = TRUE, sep = "\t")
     } else {
         data <- arrow::read_parquet(file)


### PR DESCRIPTION
This fixes #579 which is that waveica doesn't accept tabular files as input.

I also updated the profile to 23 keep the tool up to date.